### PR TITLE
Increase the timeout in testSourcePolling to 2100ms

### DIFF
--- a/core/src/test/java/org/apache/camel/kafkaconnector/CamelSourceTaskTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/CamelSourceTaskTest.java
@@ -40,7 +40,7 @@ public class CamelSourceTaskTest {
       CamelSourceTask camelSourceTask = new CamelSourceTask();
       camelSourceTask.start(props);
 
-      Thread.sleep(2000L);
+      Thread.sleep(2100L);
       List<SourceRecord> poll = camelSourceTask.poll();
       assertEquals(2, poll.size());
       assertEquals("mytopic", poll.get(0).topic());


### PR DESCRIPTION
The `testSourcePolling` seems to be very flaky for me with the current 2000ms sleep as described in #40. Increasing it to 2100ms seems to fix my issue. Do we have any better ide how to fix it then this?