### PR TITLE
Integration tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,6 +57,8 @@
         <version.maven.bundle>3.5.1</version.maven.bundle>
         <version.maven.jar>3.1.0</version.maven.jar>
         <version.maven.failsafe>2.22.1</version.maven.failsafe>
+        <version.scala.library>2.12.4</version.scala.library>
+        <version.testcontainers>1.12.0</version.testcontainers>
     </properties>
 
     <repositories>
@@ -91,102 +93,135 @@
         </pluginRepository>
     </pluginRepositories>
 
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-main</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-telegram</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-sjms2</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-aws-sqs</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-aws-s3</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-aws-sns</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-aws-kinesis</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.9</version>
-        </dependency>
-<!--        XXX: once upgrading to camel 3.0.0-M4 or newer we can switch activemq-client with this:-->
-<!--        <dependency>-->
-<!--            <groupId>org.apache.activemq</groupId>-->
-<!--            <artifactId>artemis-jms-client</artifactId>-->
-<!--            <version>2.9.0</version>-->
-<!--        </dependency>-->
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-client</artifactId>
-            <version>5.15.9</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-api</artifactId>
-            <version>${kafka.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-core</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-main</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-telegram</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-sjms2</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-aws-sqs</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-aws-s3</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-aws-sns</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-aws-kinesis</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+    <!--        XXX: once upgrading to camel 3.0.0-M4 or newer we can switch activemq-client with this:-->
+    <!--        <dependency>-->
+    <!--            <groupId>org.apache.activemq</groupId>-->
+    <!--            <artifactId>artemis-jms-client</artifactId>-->
+    <!--            <version>2.9.0</version>-->
+    <!--        </dependency>-->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>5.15.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-api</artifactId>
+                <version>${kafka.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-runtime</artifactId>
+                <version>${kafka.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.12</artifactId>
+                <version>${kafka.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jcl</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${version.scala.library}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>kafka</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <pluginManagement>
             <plugins>
@@ -240,6 +275,21 @@
                             <phase>verify</phase>
                             <goals>
                                 <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${version.maven.failsafe}</version>
+                    <executions>
+                        <execution>
+                            <id>integration-test</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
                             </goals>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <modules>
         <module>parent</module>
         <module>core</module>
+        <module>tests</module>
     </modules>
 
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.kafkaconnector</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <packaging>jar</packaging>
+
+    <name>Camel-Kafka-Connector Tests</name>
+    <description>Camel Kafka Connector Tests</description>
+
+    <artifactId>tests</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.kafkaconnector</groupId>
+            <artifactId>camel-kafka-connector</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jcl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/ConnectorPropertyProducer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/ConnectorPropertyProducer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import java.util.Properties;
+
+/**
+ * An interface for producing different types of connector properties that match
+ * an specific type of connector in test. Examples of runtime equivalent for this
+ * file are the CamelSinkConnector.properties and the CamelSourceConnector.properties
+ * files
+ */
+public interface ConnectorPropertyProducer {
+
+    /**
+     * Gets the properties used to configure the connector
+     * @return a Properties object containing the set of properties for the connector
+     */
+    Properties getProperties();
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/ConsumerPropertyProducer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/ConsumerPropertyProducer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import java.util.Properties;
+
+/**
+ * An interface to produce properties that can be used to configure a Kafka consumer. The
+ * CLI runtime equivalent for this file is the consumer.properties file from the Kafka
+ * provided along with the Kafka deliverable
+ *
+ */
+public interface ConsumerPropertyProducer {
+
+    /**
+     * Gets the properties used to configure the consumer
+     * @return a Properties object containing the set of properties for the consumer
+     */
+    Properties getProperties();
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/DefaultConsumerPropertyProducer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/DefaultConsumerPropertyProducer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+
+import java.util.Properties;
+import java.util.UUID;
+
+
+/**
+ * A property producer that can be used to create a Kafka consumer with a minimum
+ * set of configurations that can consume from a Kafka topic.
+ *
+ * The consumer behavior from using this set of properties causes the consumer to
+ * consumes all published messages "from-beginning".
+ */
+public class DefaultConsumerPropertyProducer implements ConsumerPropertyProducer {
+    private final String bootstrapServer;
+
+    /**
+     * Constructs the properties using the given bootstrap server
+     * @param bootstrapServer the address of the server in the format
+     *                       PLAINTEXT://${address}:${port}
+     */
+    public DefaultConsumerPropertyProducer(String bootstrapServer) {
+        this.bootstrapServer = bootstrapServer;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return props;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/DefaultKafkaConnectPropertyProducer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/DefaultKafkaConnectPropertyProducer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+
+import java.util.Properties;
+
+
+/**
+ * A set of properties for the Kafka connect runtime that match the standard configuration
+ * used for the standalone CLI connect runtime.
+ */
+public class DefaultKafkaConnectPropertyProducer implements KafkaConnectPropertyProducer {
+    private final String bootstrapServer;
+
+    /**
+     * Constructs the properties using the given bootstrap server
+     * @param bootstrapServer the address of the server in the format
+     *                       PLAINTEXT://${address}:${port}
+     */
+    public DefaultKafkaConnectPropertyProducer(String bootstrapServer) {
+        this.bootstrapServer = bootstrapServer;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties props = new Properties();
+
+        props.put(StandaloneConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        props.put(StandaloneConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        props.put(StandaloneConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        props.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, this.getClass().getResource("/").getPath() + "connect.offsets");
+        props.put(StandaloneConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, "10000");
+        props.put(StandaloneConfig.PLUGIN_PATH_CONFIG, "");
+        props.put(StandaloneConfig.REST_PORT_CONFIG, "9999");
+        return props;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectPropertyProducer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectPropertyProducer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import java.util.Properties;
+
+
+/**
+ * An interface for producing different types of Kafka connect properties. The CLI runtime
+ * equivalent for this file is the connect-standalone.properties
+ */
+public interface KafkaConnectPropertyProducer {
+
+    /**
+     * Gets the properties used to configure the Kafka connect runtime
+     * @return a Properties object containing the set of properties for the Kafka connect
+     * runtime
+     */
+    Properties getProperties();
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectRunner.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectRunner.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.Worker;
+import org.apache.kafka.connect.runtime.WorkerInfo;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestServer;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
+import org.apache.kafka.connect.storage.FileOffsetBackingStore;
+import org.apache.kafka.connect.util.ConnectUtils;
+import org.apache.kafka.connect.util.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static junit.framework.TestCase.fail;
+
+/**
+ * An embeddable Kafka Connect runtime for usage during the tests. It is equivalent
+ * to the Kafka connect standalone CLI
+ */
+public class KafkaConnectRunner {
+    private static final Logger log = LoggerFactory.getLogger(KafkaConnectRunner.class);
+
+    private final String bootstrapServer;
+    private final KafkaConnectPropertyProducer kafkaConnectPropertyProducer;
+    private final List<ConnectorPropertyProducer> connectorPropertyProducers = new ArrayList<>();
+
+    private Connect connect;
+    private Herder herder;
+
+    /**
+     * Constructs the properties using the given bootstrap server
+     * @param bootstrapServer the address of the server in the format
+     *                       PLAINTEXT://${address}:${port}
+     */
+    public KafkaConnectRunner(String bootstrapServer) {
+        this.bootstrapServer = bootstrapServer;
+        this.kafkaConnectPropertyProducer = new DefaultKafkaConnectPropertyProducer(bootstrapServer);
+    }
+
+
+    /**
+     * here does not seem to be a public interface for embedding a Kafka connect runtime,
+     * therefore, this code is modeled from the behavior taken from
+     * https://github.com/apache/kafka/blob/2.1/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+     * and performs the initialization in a roughly similar manner.
+     *
+     */
+    private void init() {
+        log.info("Started worked initialization");
+
+        Time time = Time.SYSTEM;
+
+        // Initializes the system runtime information and logs some of the information
+        WorkerInfo initInfo = new WorkerInfo();
+        initInfo.logAll();
+
+        Properties props = kafkaConnectPropertyProducer.getProperties();
+
+        Map<String, String> standAloneProperties = Utils.propsToStringMap(props);
+
+        // Not needed, but we need this one to initialize the worker
+        Plugins plugins = new Plugins(standAloneProperties);
+
+        StandaloneConfig config = new StandaloneConfig(standAloneProperties);
+        String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
+
+        RestServer rest = new RestServer(config);
+
+        /*
+         According to the Kafka source code "... Worker runs a (dynamic) set of tasks
+         in a set of threads, doing the work of actually moving data to/from Kafka ..."
+         */
+        Worker worker = new Worker(bootstrapServer, time, plugins, config, new FileOffsetBackingStore());
+
+        /*
+        From Kafka source code: " ... The herder interface tracks and manages workers
+        and connectors ..."
+         */
+        herder = new StandaloneHerder(worker, kafkaClusterId);
+        connect = new Connect(herder, rest);
+        log.info("Finished initializing the worker");
+    }
+
+    /**
+     * Offers the list of connector properties producers to be configured prior to running
+     * the embeddable connect runtime
+     * @return A list object that can be modified to include or remove connector property
+     * producers
+     */
+    public List<ConnectorPropertyProducer> getConnectorPropertyProducers() {
+        return connectorPropertyProducers;
+    }
+
+
+    private void callTestErrorHandler(Properties connectorProps, Throwable error) {
+        if (error != null) {
+            TestCommon.failOnConnectorError(error, connectorProps,
+                    (String) connectorProps.get(ConnectorConfig.NAME_CONFIG));
+        }
+        else {
+            log.debug("Created connector {}", connectorProps.get(ConnectorConfig.NAME_CONFIG));
+        }
+    }
+
+
+    public void initializeConnector(ConnectorPropertyProducer connectorPropertyProducer) throws ExecutionException, InterruptedException {
+        Properties connectorProps = connectorPropertyProducer.getProperties();
+
+        FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>((error, info) ->
+                callTestErrorHandler(connectorProps, error));
+
+        herder.putConnectorConfig(
+                connectorProps.getProperty(ConnectorConfig.NAME_CONFIG),
+                Utils.propsToStringMap(connectorProps), false, cb);
+
+        cb.get();
+    }
+
+    private static void failOnKafkaConnectInitialization(Throwable error) {
+        log.error("Failed to initialize the embedded Kafka Connect Runtime: {}",
+                error.getMessage(), error);
+
+        fail("Failed to initialize the embedded Kafka Connect Runtime: " +
+                error.getMessage());
+    }
+
+    /**
+     * Run the embeddable Kafka connect runtime
+     * @return true if successfully started the runtime or false otherwise
+     */
+    public boolean run() {
+        init();
+
+        log.info("Starting the connect interface");
+        connect.start();
+        log.info("Started the connect interface");
+
+        for (ConnectorPropertyProducer propertyProducer : connectorPropertyProducers) {
+            try {
+                initializeConnector(propertyProducer);
+            } catch(InterruptedException | ExecutionException e){
+                failOnKafkaConnectInitialization(e);
+
+                return false;
+            }
+        }
+
+        connect.awaitStop();
+        return true;
+    }
+
+
+    /**
+     * Stops the embeddable Kafka connect runtime
+     */
+    public void stop() {
+        connect.stop();
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/TestCommon.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/TestCommon.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+import static junit.framework.TestCase.fail;
+
+/**
+ * Common test constants and utilities
+ */
+public final class TestCommon {
+    private static final Logger log = LoggerFactory.getLogger(TestCommon.class);
+
+    private TestCommon() {}
+
+    /**
+     * The default topic for usage during the tests
+     */
+    public static final String DEFAULT_TEST_TOPIC = "mytopic";
+
+
+    public static void failOnConnectorError(Throwable error, Properties connectorProps, String name) {
+        log.error("Failed to create job for {} with properties", name, connectorProps,
+                error);
+        fail("Failed to create job for " + name);
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/TestMessageConsumer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/TestMessageConsumer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.function.Predicate;
+
+/**
+ * A very simple test message consumer that can consume messages of different types
+ * @param <K> Key vtype
+ * @param <V> Value type
+ */
+public class TestMessageConsumer<K,V> {
+    private final ConsumerPropertyProducer propertyProducer;
+
+
+    /**
+     * Constructs the properties using the given bootstrap server
+     * @param bootstrapServer the address of the server in the format
+     *                       PLAINTEXT://${address}:${port}
+     */
+    public TestMessageConsumer(String bootstrapServer) {
+        this.propertyProducer = new DefaultConsumerPropertyProducer(bootstrapServer);
+    }
+
+
+    /**
+     * Consumes message from the given topic until the predicate returns false
+     * @param topic the topic to consume the messages from
+     * @param predicate the predicate to test when the messages arrive
+     */
+    public void consume(String topic, Predicate<ConsumerRecord<K,V>> predicate) {
+        Properties props = propertyProducer.getProperties();
+
+        KafkaConsumer<K, V> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(Arrays.asList(topic));
+
+        // TODO: handle failures, timeouts, etc
+        while (true) {
+            ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(10));
+            for (ConsumerRecord<K, V> record : records) {
+                if (!predicate.test(record)) {
+                    return;
+                }
+            }
+        }
+    }
+
+
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelSourceTimerITCase.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelSourceTimerITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector.source.timer;
+
+import org.apache.camel.kakfaconnector.KafkaConnectRunner;
+import org.apache.camel.kakfaconnector.TestCommon;
+import org.apache.camel.kakfaconnector.TestMessageConsumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+import static org.junit.Assert.fail;
+
+/**
+ * A simple test case that checks whether the timer produces the expected number of
+ * messages
+ */
+public class CamelSourceTimerITCase {
+    private static final Logger log = LoggerFactory.getLogger(CamelSourceTimerITCase.class);
+
+    @Rule
+    public KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+
+    private int received = 0;
+    private final int expect = 10;
+    private KafkaConnectRunner kafkaConnectRunner;
+
+    @Before
+    public void setUp() {
+        kafkaConnectRunner =  new KafkaConnectRunner(kafka.getBootstrapServers());
+
+        CamelTimerPropertyProducer testProperties = new CamelTimerPropertyProducer(1,
+                TestCommon.DEFAULT_TEST_TOPIC, expect);
+
+        kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
+
+        log.info("Kafka bootstrap server running at address " + kafka.getBootstrapServers());
+    }
+
+    private boolean checkRecord(ConsumerRecord<String, String> record) {
+        received++;
+
+        if (received == expect) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Test
+    public void testLaunchConnector() {
+        ExecutorService service = Executors.newCachedThreadPool();
+        service.submit(() -> kafkaConnectRunner.run());
+
+        log.debug("Creating the consumer ...");
+        TestMessageConsumer<String,String> testMessageConsumer = new TestMessageConsumer<>(kafka.getBootstrapServers());
+        testMessageConsumer.consume(TestCommon.DEFAULT_TEST_TOPIC, this::checkRecord);
+        log.debug("Created the consumer ...");
+
+        kafkaConnectRunner.stop();
+        Assert.assertTrue(received == expect);
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelTimerPropertyProducer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelTimerPropertyProducer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector.source.timer;
+
+import org.apache.camel.kakfaconnector.ConnectorPropertyProducer;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.util.Properties;
+
+public class CamelTimerPropertyProducer implements ConnectorPropertyProducer {
+    private final int tasksMax;
+    private final String topic;
+    private int repeatCount;
+
+    public CamelTimerPropertyProducer(int tasksMax, String topic, int repeatCount) {
+        this.tasksMax = tasksMax;
+        this.topic = topic;
+        this.repeatCount = repeatCount;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties connectorProps = new Properties();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelSourceConnector");
+        connectorProps.put("tasks.max", String.valueOf(tasksMax));
+
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put("camel.source.url", String.format("timer:kafkaconnector?repeatCount=%d", repeatCount));
+        connectorProps.put("camel.source.kafka.topic", topic);
+
+        return connectorProps;
+    }
+}


### PR DESCRIPTION
Sending this as preview for the proposed integration test infrastructure and to collect some feedback. 

Basically it uses [Test Containers](https://www.testcontainers.org/) library to launch a stand-alone Kafka instance that is then used for the tests. 
The code brings an embeddable Kafka Connect runtime that reproduces the behavior of running the standalone connect CLI. 
The code is still rudimentary on some parts - some of them are commented as TODO - but, overall, should give an idea of the implementation.

The code leverages the failsafe plugin so the tests can be run with:
```mvn clean verify package```.

