### PR TITLE
Adds integration tests for the Camel JMS sink and source

### DIFF
--- a/tests/src/test/java/org/apache/camel/kakfaconnector/ArtemisContainer.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/ArtemisContainer.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * A specialized container that can be used to create Apache Artemis broker
+ * instances.
+ */
+public class ArtemisContainer extends GenericContainer {
+    private static final int DEFAULT_MQTT_PORT = 1883;
+    private static final int DEFAULT_AMQP_PORT = 5672;
+    private static final int DEFAULT_ADMIN_PORT = 8161;
+    private static final int DEFAULT_ACCEPTOR_PORT = 61616;
+
+
+    public ArtemisContainer() {
+        super(new ImageFromDockerfile()
+                .withFileFromClasspath("Dockerfile",
+                        "org/apache/camel/kakfaconnector/Dockerfile"));
+
+        withExposedPorts(new Integer[]{DEFAULT_MQTT_PORT, DEFAULT_AMQP_PORT,
+                DEFAULT_ADMIN_PORT, DEFAULT_ACCEPTOR_PORT});
+
+        waitingFor(Wait.forListeningPort());
+    }
+
+
+    /**
+     * Gets the port number used for exchanging messages using the AMQP protocol
+     * @return the port number
+     */
+    public int getAMQPPort() {
+        return getMappedPort(DEFAULT_AMQP_PORT);
+    }
+
+
+    /**
+     * Gets the end point URL used exchanging messages using the AMQP protocol (ie.: tcp://host:${amqp.port})
+     * @return the end point URL as a string
+     */
+    public String getAMQPEndpoint() {
+        return String.format("tcp://localhost:%d", getAMQPPort());
+    }
+
+
+    /**
+     * Gets the port number used for exchanging messages using the MQTT protocol
+     * @return the port number
+     */
+    public int getMQTTPort() {
+        return getMappedPort(DEFAULT_MQTT_PORT);
+    }
+
+
+    /**
+     * Gets the end point URL used exchanging messages using the MQTT protocol (ie.: tcp://host:${mqtt.port})
+     * @return the end point URL as a string
+     */
+    public String getMQTTEndpoint() {
+        return String.format("tcp://localhost:%d", getMQTTPort());
+    }
+
+
+    /**
+     * Gets the port number used for accessing the web management console or the management API
+     * @return the port number
+     */
+    public int getAdminPort() {
+        return getMappedPort(DEFAULT_ADMIN_PORT);
+    }
+
+
+    /**
+     * Gets the end point URL used for accessing the web management console or the management API
+     * @return the admin URL as a string
+     */
+    public String getAdminURL() {
+        return String.format("http://localhost:%d", getAdminPort());
+    }
+
+
+    /**
+     * Gets the port number used for exchanging messages using the default acceptor port
+     * @return the port number
+     */
+    public int getDefaultAcceptorPort() {
+        return getMappedPort(DEFAULT_ACCEPTOR_PORT);
+    }
+
+
+    /**
+     * Gets the end point URL used exchanging messages through the default acceptor port
+     * @return the end point URL as a string
+     */
+    public String getDefaultAcceptorEndpoint() {
+        return String.format("tcp://localhost:%d", getDefaultAcceptorPort());
+    }
+
+
+
+    /**
+     * Gets the port number used for exchanging messages using the Openwire protocol
+     * @return the port number
+     */
+    public int getOpenwirePort() {
+        return getDefaultAcceptorPort();
+    }
+
+
+    /**
+     * Gets the end point URL used exchanging messages using the Openwire protocol (ie.: tcp://host:${amqp.port})
+     * @return the end point URL as a string
+     */
+    public String getOpenwireEndpoint() {
+        return String.format("tcp://localhost:%d", getOpenwirePort());
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/ConnectorPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/ConnectorPropertyFactory.java
@@ -18,35 +18,19 @@
 
 package org.apache.camel.kakfaconnector;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Properties;
 
-import static junit.framework.TestCase.fail;
-
 /**
- * Common test constants and utilities
+ * An interface for producing different types of connector properties that match
+ * an specific type of connector in test. Examples of runtime equivalent for this
+ * file are the CamelSinkConnector.properties and the CamelSourceConnector.properties
+ * files
  */
-public final class TestCommon {
-    private static final Logger log = LoggerFactory.getLogger(TestCommon.class);
-
-    private TestCommon() {}
+public interface ConnectorPropertyFactory {
 
     /**
-     * The default topic for usage during the tests
+     * Gets the properties used to configure the connector
+     * @return a Properties object containing the set of properties for the connector
      */
-    public static final String DEFAULT_TEST_TOPIC = "mytopic";
-
-    /**
-     * The default JMS queue name used during the tests
-     */
-    public static final String DEFAULT_JMS_QUEUE = "ckc.queue";
-
-
-    public static void failOnConnectorError(Throwable error, Properties connectorProps, String name) {
-        log.error("Failed to create job for {} with properties", name, connectorProps,
-                error);
-        fail("Failed to create job for " + name);
-    }
+    Properties getProperties();
 }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/ContainerUtil.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/ContainerUtil.java
@@ -18,35 +18,37 @@
 
 package org.apache.camel.kakfaconnector;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 
-import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 
-/**
- * Common test constants and utilities
- */
-public final class TestCommon {
-    private static final Logger log = LoggerFactory.getLogger(TestCommon.class);
-
-    private TestCommon() {}
+public class ContainerUtil {
 
     /**
-     * The default topic for usage during the tests
+     * Wait for the container to be in running state
+     * @param container the container to wait for
      */
-    public static final String DEFAULT_TEST_TOPIC = "mytopic";
+    public static void waitForInitialization(GenericContainer container) {
+        int retries = 5;
 
-    /**
-     * The default JMS queue name used during the tests
-     */
-    public static final String DEFAULT_JMS_QUEUE = "ckc.queue";
+        do {
+            boolean state = container.isRunning();
 
+            if (state == false) {
+                try {
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+                } catch (InterruptedException e) {
+                    container.stop();
+                    fail("Test interrupted");
+                }
 
-    public static void failOnConnectorError(Throwable error, Properties connectorProps, String name) {
-        log.error("Failed to create job for {} with properties", name, connectorProps,
-                error);
-        fail("Failed to create job for " + name);
+                retries--;
+            }
+            else {
+                break;
+            }
+        } while (retries > 0);
     }
 }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/DefaultKafkaConnectPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/DefaultKafkaConnectPropertyFactory.java
@@ -27,7 +27,7 @@ import java.util.Properties;
  * A set of properties for the Kafka connect runtime that match the standard configuration
  * used for the standalone CLI connect runtime.
  */
-public class DefaultKafkaConnectPropertyProducer implements KafkaConnectPropertyProducer {
+public class DefaultKafkaConnectPropertyFactory implements KafkaConnectPropertyFactory {
     private final String bootstrapServer;
 
     /**
@@ -35,7 +35,7 @@ public class DefaultKafkaConnectPropertyProducer implements KafkaConnectProperty
      * @param bootstrapServer the address of the server in the format
      *                       PLAINTEXT://${address}:${port}
      */
-    public DefaultKafkaConnectPropertyProducer(String bootstrapServer) {
+    public DefaultKafkaConnectPropertyFactory(String bootstrapServer) {
         this.bootstrapServer = bootstrapServer;
     }
 
@@ -50,6 +50,7 @@ public class DefaultKafkaConnectPropertyProducer implements KafkaConnectProperty
         props.put(StandaloneConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, "10000");
         props.put(StandaloneConfig.PLUGIN_PATH_CONFIG, "");
         props.put(StandaloneConfig.REST_PORT_CONFIG, "9999");
+
         return props;
     }
 }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectPropertyFactory.java
@@ -20,17 +20,17 @@ package org.apache.camel.kakfaconnector;
 
 import java.util.Properties;
 
+
 /**
- * An interface for producing different types of connector properties that match
- * an specific type of connector in test. Examples of runtime equivalent for this
- * file are the CamelSinkConnector.properties and the CamelSourceConnector.properties
- * files
+ * An interface for producing different types of Kafka connect properties. The CLI runtime
+ * equivalent for this file is the connect-standalone.properties
  */
-public interface ConnectorPropertyProducer {
+public interface KafkaConnectPropertyFactory {
 
     /**
-     * Gets the properties used to configure the connector
-     * @return a Properties object containing the set of properties for the connector
+     * Gets the properties used to configure the Kafka connect runtime
+     * @return a Properties object containing the set of properties for the Kafka connect
+     * runtime
      */
     Properties getProperties();
 }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectRunner.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/KafkaConnectRunner.java
@@ -52,8 +52,8 @@ public class KafkaConnectRunner {
     private static final Logger log = LoggerFactory.getLogger(KafkaConnectRunner.class);
 
     private final String bootstrapServer;
-    private final KafkaConnectPropertyProducer kafkaConnectPropertyProducer;
-    private final List<ConnectorPropertyProducer> connectorPropertyProducers = new ArrayList<>();
+    private final KafkaConnectPropertyFactory kafkaConnectPropertyFactory;
+    private final List<ConnectorPropertyFactory> connectorPropertyFactories = new ArrayList<>();
 
     private Connect connect;
     private Herder herder;
@@ -65,7 +65,7 @@ public class KafkaConnectRunner {
      */
     public KafkaConnectRunner(String bootstrapServer) {
         this.bootstrapServer = bootstrapServer;
-        this.kafkaConnectPropertyProducer = new DefaultKafkaConnectPropertyProducer(bootstrapServer);
+        this.kafkaConnectPropertyFactory = new DefaultKafkaConnectPropertyFactory(bootstrapServer);
     }
 
 
@@ -85,7 +85,7 @@ public class KafkaConnectRunner {
         WorkerInfo initInfo = new WorkerInfo();
         initInfo.logAll();
 
-        Properties props = kafkaConnectPropertyProducer.getProperties();
+        Properties props = kafkaConnectPropertyFactory.getProperties();
 
         Map<String, String> standAloneProperties = Utils.propsToStringMap(props);
 
@@ -118,8 +118,8 @@ public class KafkaConnectRunner {
      * @return A list object that can be modified to include or remove connector property
      * producers
      */
-    public List<ConnectorPropertyProducer> getConnectorPropertyProducers() {
-        return connectorPropertyProducers;
+    public List<ConnectorPropertyFactory> getConnectorPropertyProducers() {
+        return connectorPropertyFactories;
     }
 
 
@@ -134,8 +134,8 @@ public class KafkaConnectRunner {
     }
 
 
-    public void initializeConnector(ConnectorPropertyProducer connectorPropertyProducer) throws ExecutionException, InterruptedException {
-        Properties connectorProps = connectorPropertyProducer.getProperties();
+    public void initializeConnector(ConnectorPropertyFactory connectorPropertyFactory) throws ExecutionException, InterruptedException {
+        Properties connectorProps = connectorPropertyFactory.getProperties();
 
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>((error, info) ->
                 callTestErrorHandler(connectorProps, error));
@@ -166,7 +166,7 @@ public class KafkaConnectRunner {
         connect.start();
         log.info("Started the connect interface");
 
-        for (ConnectorPropertyProducer propertyProducer : connectorPropertyProducers) {
+        for (ConnectorPropertyFactory propertyProducer : connectorPropertyFactories) {
             try {
                 initializeConnector(propertyProducer);
             } catch(InterruptedException | ExecutionException e){

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/clients/jms/JMSClient.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/clients/jms/JMSClient.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.camel.kakfaconnector.clients.jms;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A basic multi-protocol JMS client
+ */
+public class JMSClient {
+    private static final Logger logger = LoggerFactory.getLogger(JMSClient.class);
+
+    private final String url;
+    private Connection connection = null;
+    private Session session = null;
+
+    private final Function<String, ? extends ConnectionFactory> connectionFactory;
+    private final Function<String, ? extends Queue> destinationFactory;
+
+    public JMSClient(Function<String, ? extends ConnectionFactory> connectionFactory,
+                     Function<String, ? extends Queue> destinationFactory,
+                     String url) {
+        this.connectionFactory = connectionFactory;
+        this.destinationFactory = destinationFactory;
+        this.url = url;
+    }
+
+
+    @SuppressWarnings("UnusedReturnValue")
+    public static Throwable capturingClose(MessageProducer closeable) {
+        logger.debug("Closing the producer ");
+
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Throwable t) {
+                logger.warn("Error closing the producer: {}", t.getMessage(), t);
+                return t;
+            }
+        }
+        return null;
+    }
+
+    private static void capturingClose(Session closeable) {
+        logger.debug("Closing the session ");
+
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Throwable t) {
+                logger.warn("Error closing the session: {}", t.getMessage(), t);
+            }
+        }
+    }
+
+    private static void capturingClose(MessageConsumer closeable) {
+        logger.debug("Closing the consumer");
+
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Throwable t) {
+                logger.warn("Error closing the consumer: {}", t.getMessage(), t);
+            }
+        }
+    }
+
+    private static void capturingClose(Connection closeable) {
+        logger.debug("Closing the connection");
+
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Throwable t) {
+                logger.warn("Error closing the connection: {}", t.getMessage(), t);
+            }
+        }
+    }
+
+
+    public void start() throws Exception {
+        logger.debug("Starting the JMS client");
+
+        try {
+            final ConnectionFactory factory = connectionFactory.apply(url);
+
+            logger.debug("Creating the connection");
+            connection = factory.createConnection();
+            logger.debug("Connection created successfully");
+
+            logger.debug("Creating the JMS session");
+            this.session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            logger.debug("JMS session created successfully");
+        } catch (Throwable t) {
+            logger.trace("Something wrong happened while initializing the JMS client: {}", t.getMessage(), t);
+
+            capturingClose(connection);
+            throw t;
+        }
+
+        connection.start();
+    }
+
+    public void stop() {
+        try {
+            logger.debug("Stopping the JMS session");
+            capturingClose(session);
+
+            logger.debug("Stopping the JMS connection");
+            capturingClose(connection);
+        }
+        finally {
+            session = null;
+            connection = null;
+        }
+    }
+
+    private Destination createDestination(final String destinationName) {
+        return destinationFactory.apply(destinationName);
+    }
+
+
+    /**
+     * Receives data from a JMS queue or topic
+     * @param queue the queue or topic to receive data from
+     * @param predicate the predicate used to test each received message
+     * @throws JMSException
+     */
+    public void receive(final String queue, Predicate<Message> predicate) throws JMSException {
+        final long timeout = 3000;
+
+        MessageConsumer consumer = null;
+
+        try {
+            consumer = session.createConsumer(createDestination(queue));
+
+            while (true) {
+                final Message message = consumer.receive(timeout);
+
+                if (!predicate.test(message)) {
+                    return;
+                }
+            }
+        }
+        finally {
+            capturingClose(consumer);
+        }
+    }
+
+
+    /**
+     * Sends data to a JMS queue or topic
+     * @param queue the queue or topic to send data to
+     * @param data the (string) data to send
+     * @throws JMSException
+     */
+    public void send(final String queue, final String data) throws JMSException {
+        MessageProducer producer = null;
+
+        try {
+            producer = session.createProducer(createDestination(queue));
+
+            producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            producer.setTimeToLive(0);
+
+            Message message = session.createTextMessage(data);
+
+            producer.send(message);
+        } finally {
+            capturingClose(producer);
+        }
+    }
+
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/ConsumerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/ConsumerPropertyFactory.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.apache.camel.kakfaconnector;
+package org.apache.camel.kakfaconnector.clients.kafka;
 
 import java.util.Properties;
 
@@ -26,7 +26,7 @@ import java.util.Properties;
  * provided along with the Kafka deliverable
  *
  */
-public interface ConsumerPropertyProducer {
+public interface ConsumerPropertyFactory {
 
     /**
      * Gets the properties used to configure the consumer

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/DefaultConsumerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/DefaultConsumerPropertyFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector.clients.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.util.Properties;
+import java.util.UUID;
+
+
+/**
+ * A property producer that can be used to create a Kafka consumer with a minimum
+ * set of configurations that can consume from a Kafka topic.
+ *
+ * The consumer behavior from using this set of properties causes the consumer to
+ * consumes all published messages "from-beginning".
+ */
+public class DefaultConsumerPropertyFactory implements ConsumerPropertyFactory {
+    private final String bootstrapServer;
+
+    /**
+     * Constructs the properties using the given bootstrap server
+     * @param bootstrapServer the address of the server in the format
+     *                       PLAINTEXT://${address}:${port}
+     */
+    public DefaultConsumerPropertyFactory(String bootstrapServer) {
+        this.bootstrapServer = bootstrapServer;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getName());
+        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getName());
+        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return props;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/DefaultProducerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/DefaultProducerPropertyFactory.java
@@ -16,22 +16,15 @@
  *
  */
 
-package org.apache.camel.kakfaconnector;
+package org.apache.camel.kakfaconnector.clients.kafka;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Properties;
 import java.util.UUID;
 
-
-/**
- * A property producer that can be used to create a Kafka consumer with a minimum
- * set of configurations that can consume from a Kafka topic.
- *
- * The consumer behavior from using this set of properties causes the consumer to
- * consumes all published messages "from-beginning".
- */
-public class DefaultConsumerPropertyProducer implements ConsumerPropertyProducer {
+public class DefaultProducerPropertyFactory implements ProducerPropertyFactory {
     private final String bootstrapServer;
 
     /**
@@ -39,18 +32,21 @@ public class DefaultConsumerPropertyProducer implements ConsumerPropertyProducer
      * @param bootstrapServer the address of the server in the format
      *                       PLAINTEXT://${address}:${port}
      */
-    public DefaultConsumerPropertyProducer(String bootstrapServer) {
+    public DefaultProducerPropertyFactory(String bootstrapServer) {
         this.bootstrapServer = bootstrapServer;
     }
 
     @Override
     public Properties getProperties() {
         Properties props = new Properties();
-        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
-        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
-        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class.getName());
+
         return props;
     }
 }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/ProducerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/clients/kafka/ProducerPropertyFactory.java
@@ -16,21 +16,21 @@
  *
  */
 
-package org.apache.camel.kakfaconnector;
+package org.apache.camel.kakfaconnector.clients.kafka;
 
 import java.util.Properties;
 
-
 /**
- * An interface for producing different types of Kafka connect properties. The CLI runtime
- * equivalent for this file is the connect-standalone.properties
+ * An interface to produce properties that can be used to configure a Kafka consumer. The
+ * CLI runtime equivalent for this file is the consumer.properties file from the Kafka
+ * provided along with the Kafka deliverable
+ *
  */
-public interface KafkaConnectPropertyProducer {
+public interface ProducerPropertyFactory {
 
     /**
-     * Gets the properties used to configure the Kafka connect runtime
-     * @return a Properties object containing the set of properties for the Kafka connect
-     * runtime
+     * Gets the properties used to configure the consumer
+     * @return a Properties object containing the set of properties for the consumer
      */
     Properties getProperties();
 }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/sink/jms/CamelJMSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/sink/jms/CamelJMSPropertyFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector.sink.jms;
+
+import org.apache.camel.kakfaconnector.ConnectorPropertyFactory;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.util.Properties;
+
+
+/**
+ * Creates the set of properties used by a Camel JMS Sink Connector
+ */
+class CamelJMSPropertyFactory implements ConnectorPropertyFactory {
+    private final int tasksMax;
+    private final String topic;
+    private final String queue;
+
+    private final String brokerURL;
+
+    CamelJMSPropertyFactory(int tasksMax, String topic, String queue, String brokerURL) {
+        this.tasksMax = tasksMax;
+        this.topic = topic;
+        this.queue = queue;
+        this.brokerURL = brokerURL;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties connectorProps = new Properties();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelJmsSinkConnector");
+        connectorProps.put("tasks.max", String.valueOf(tasksMax));
+
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put("camel.sink.url", "sjms2://queue:" + queue);
+        connectorProps.put("topics", topic);
+
+        connectorProps.put("camel.component.sjms2.connection-factory", "#class:org.apache.activemq.ActiveMQConnectionFactory");
+        connectorProps.put("camel.component.sjms2.connection-factory.brokerURL", brokerURL);
+
+        return connectorProps;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/sink/jms/CamelSinkJMSITCase.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/sink/jms/CamelSinkJMSITCase.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.camel.kakfaconnector.sink.jms;
+
+import org.apache.camel.kakfaconnector.ArtemisContainer;
+import org.apache.camel.kakfaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kakfaconnector.ContainerUtil;
+import org.apache.camel.kakfaconnector.KafkaConnectRunner;
+import org.apache.camel.kakfaconnector.TestCommon;
+import org.apache.camel.kakfaconnector.clients.jms.JMSClient;
+import org.apache.camel.kakfaconnector.clients.kafka.KafkaClient;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ * A simple test case that checks whether the timer produces the expected number of
+ * messages
+ */
+public class CamelSinkJMSITCase {
+    private static final Logger log = LoggerFactory.getLogger(CamelSinkJMSITCase.class);
+
+    @Rule
+    public KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+
+    @Rule
+    public ArtemisContainer artemis = new ArtemisContainer();
+
+    private int received = 0;
+    private final int expect = 10;
+    private KafkaConnectRunner kafkaConnectRunner;
+
+    @Before
+    public void setUp() {
+        ContainerUtil.waitForInitialization(kafka);
+        log.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
+
+        ContainerUtil.waitForInitialization(artemis);
+        log.info("Artemis broker running at {}", artemis.getAdminURL());
+
+        ConnectorPropertyFactory testProperties = new CamelJMSPropertyFactory(1,
+                TestCommon.DEFAULT_TEST_TOPIC, TestCommon.DEFAULT_JMS_QUEUE, artemis.getDefaultAcceptorEndpoint());
+
+        kafkaConnectRunner =  new KafkaConnectRunner(kafka.getBootstrapServers());
+        kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
+    }
+
+    private boolean checkRecord(Message jmsMessage) {
+        if (jmsMessage instanceof TextMessage) {
+            try {
+                log.debug("Received: {}", ((TextMessage) jmsMessage).getText());
+
+                received++;
+
+                if (received == expect) {
+                    return false;
+                }
+
+                return true;
+            } catch (JMSException e) {
+                log.error("Failed to read message: {}", e.getMessage(), e);
+                fail("Failed to read message: " + e.getMessage());
+            }
+        }
+
+        return false;
+    }
+
+    @Test
+    public void testBasicSendReceive() {
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+
+            ExecutorService service = Executors.newFixedThreadPool(2);
+            service.submit(() -> kafkaConnectRunner.run());
+
+            log.debug("Creating the consumer ...");
+            service.submit(() -> consumeJMSMessages(latch));
+
+            KafkaClient<String,String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+
+            for (int i = 0; i < expect; i++) {
+                kafkaClient.produce(TestCommon.DEFAULT_TEST_TOPIC, "Sink test message " + i);
+            }
+
+            log.debug("Created the consumer ... About to receive messages");
+
+            if (latch.await(35, TimeUnit.SECONDS)) {
+                Assert.assertTrue("Didn't process the expected amount of messages: " + received + " != " + expect,
+                        received == expect);
+            }
+            else {
+                fail("Failed to receive the messages within the specified time");
+            }
+
+            kafkaConnectRunner.stop();
+        } catch (Exception e) {
+            log.error("JMS test failed: {}", e.getMessage(), e);
+            fail(e.getMessage());
+        }
+
+    }
+
+    private void consumeJMSMessages(CountDownLatch latch) {
+        JMSClient jmsClient = null;
+
+        try {
+            jmsClient = new JMSClient(org.apache.activemq.ActiveMQConnectionFactory::new,
+                    org.apache.activemq.command.ActiveMQQueue::new,
+                    artemis.getOpenwireEndpoint());
+
+            jmsClient.start();
+
+            for (int i = 0; i < expect; i++) {
+                jmsClient.receive(TestCommon.DEFAULT_JMS_QUEUE, this::checkRecord);
+            }
+
+        } catch (Exception e) {
+            log.error("JMS test failed: {}", e.getMessage(), e);
+            fail(e.getMessage());
+        } finally {
+            latch.countDown();
+
+            if (jmsClient != null) {
+                jmsClient.stop();
+            }
+        }
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/source/jms/CamelJMSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/source/jms/CamelJMSPropertyFactory.java
@@ -16,35 +16,44 @@
  *
  */
 
-package org.apache.camel.kakfaconnector.source.timer;
+package org.apache.camel.kakfaconnector.source.jms;
 
-import org.apache.camel.kakfaconnector.ConnectorPropertyProducer;
+import org.apache.camel.kakfaconnector.ConnectorPropertyFactory;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 import java.util.Properties;
 
-public class CamelTimerPropertyProducer implements ConnectorPropertyProducer {
+
+/**
+ * Creates the set of properties used by a Camel JMS Sink Connector
+ */
+class CamelJMSPropertyFactory implements ConnectorPropertyFactory {
     private final int tasksMax;
     private final String topic;
-    private int repeatCount;
+    private final String queue;
 
-    public CamelTimerPropertyProducer(int tasksMax, String topic, int repeatCount) {
+    private final String brokerURL;
+
+    CamelJMSPropertyFactory(int tasksMax, String topic, String queue, String brokerURL) {
         this.tasksMax = tasksMax;
         this.topic = topic;
-        this.repeatCount = repeatCount;
+        this.queue = queue;
+        this.brokerURL = brokerURL;
     }
 
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelJMSSourceConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
         connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
-        connectorProps.put("camel.source.url", String.format("timer:kafkaconnector?repeatCount=%d", repeatCount));
+        connectorProps.put("camel.source.url", "sjms2://queue:" + queue);
         connectorProps.put("camel.source.kafka.topic", topic);
+        connectorProps.put("camel.component.sjms2.connection-factory", "#class:org.apache.activemq.ActiveMQConnectionFactory");
+        connectorProps.put("camel.component.sjms2.connection-factory.brokerURL", brokerURL);
 
         return connectorProps;
     }

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/source/jms/CamelSourceJMSITCase.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/source/jms/CamelSourceJMSITCase.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.camel.kakfaconnector.source.jms;
+
+import org.apache.camel.kakfaconnector.ArtemisContainer;
+import org.apache.camel.kakfaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kakfaconnector.ContainerUtil;
+import org.apache.camel.kakfaconnector.KafkaConnectRunner;
+import org.apache.camel.kakfaconnector.TestCommon;
+import org.apache.camel.kakfaconnector.clients.jms.JMSClient;
+import org.apache.camel.kakfaconnector.clients.kafka.KafkaClient;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.fail;
+
+/**
+ * A simple test case that checks whether the timer produces the expected number of
+ * messages
+ */
+public class CamelSourceJMSITCase {
+    private static final Logger log = LoggerFactory.getLogger(CamelSourceJMSITCase.class);
+
+    @Rule
+    public KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+
+    @Rule
+    public ArtemisContainer artemis = new ArtemisContainer();
+
+    private int received = 0;
+    private final int expect = 10;
+    private KafkaConnectRunner kafkaConnectRunner;
+
+    @Before
+    public void setUp() {
+        ContainerUtil.waitForInitialization(kafka);
+        log.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
+
+        ContainerUtil.waitForInitialization(artemis);
+        log.info("Artemis broker running at " + artemis.getAdminURL());
+
+
+        ConnectorPropertyFactory testProperties = new CamelJMSPropertyFactory(1,
+                TestCommon.DEFAULT_TEST_TOPIC, TestCommon.DEFAULT_JMS_QUEUE, artemis.getDefaultAcceptorEndpoint());
+
+        kafkaConnectRunner =  new KafkaConnectRunner(kafka.getBootstrapServers());
+        kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
+    }
+
+    private boolean checkRecord(ConsumerRecord<String, String> record) {
+        log.debug("Received: {}", record.value());
+        received++;
+
+        if (received == expect) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Test
+    public void testBasicSendReceive() {
+        try {
+            ExecutorService service = Executors.newCachedThreadPool();
+            service.submit(() -> kafkaConnectRunner.run());
+
+            JMSClient jmsProducer = new JMSClient(
+                    org.apache.activemq.ActiveMQConnectionFactory::new,
+                    org.apache.activemq.command.ActiveMQQueue::new,
+                    artemis.getOpenwireEndpoint());
+
+            jmsProducer.start();
+            for (int i = 0; i < expect; i++) {
+                jmsProducer.send(TestCommon.DEFAULT_JMS_QUEUE, "Test message " + i);
+            }
+            jmsProducer.stop();
+
+            log.debug("Creating the consumer ...");
+            KafkaClient<String,String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+            kafkaClient.consume(TestCommon.DEFAULT_TEST_TOPIC, this::checkRecord);
+            log.debug("Created the consumer ...");
+
+            kafkaConnectRunner.stop();
+            Assert.assertTrue("Didn't process the expected amount of messages", received == expect);
+        } catch (Exception e) {
+            log.error("JMS test failed: {}", e.getMessage(), e);
+            fail(e.getMessage());
+        }
+
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelSourceTimerITCase.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelSourceTimerITCase.java
@@ -20,7 +20,7 @@ package org.apache.camel.kakfaconnector.source.timer;
 
 import org.apache.camel.kakfaconnector.KafkaConnectRunner;
 import org.apache.camel.kakfaconnector.TestCommon;
-import org.apache.camel.kakfaconnector.TestMessageConsumer;
+import org.apache.camel.kakfaconnector.clients.kafka.KafkaClient;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,8 +33,6 @@ import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
-
-import static org.junit.Assert.fail;
 
 /**
  * A simple test case that checks whether the timer produces the expected number of
@@ -52,14 +50,18 @@ public class CamelSourceTimerITCase {
 
     @Before
     public void setUp() {
+
+
         kafkaConnectRunner =  new KafkaConnectRunner(kafka.getBootstrapServers());
 
-        CamelTimerPropertyProducer testProperties = new CamelTimerPropertyProducer(1,
+        CamelTimerPropertyFactory testProperties = new CamelTimerPropertyFactory(1,
                 TestCommon.DEFAULT_TEST_TOPIC, expect);
 
         kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
 
         log.info("Kafka bootstrap server running at address " + kafka.getBootstrapServers());
+
+
     }
 
     private boolean checkRecord(ConsumerRecord<String, String> record) {
@@ -78,8 +80,8 @@ public class CamelSourceTimerITCase {
         service.submit(() -> kafkaConnectRunner.run());
 
         log.debug("Creating the consumer ...");
-        TestMessageConsumer<String,String> testMessageConsumer = new TestMessageConsumer<>(kafka.getBootstrapServers());
-        testMessageConsumer.consume(TestCommon.DEFAULT_TEST_TOPIC, this::checkRecord);
+        KafkaClient<String,String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+        kafkaClient.consume(TestCommon.DEFAULT_TEST_TOPIC, this::checkRecord);
         log.debug("Created the consumer ...");
 
         kafkaConnectRunner.stop();

--- a/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelTimerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kakfaconnector/source/timer/CamelTimerPropertyFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kakfaconnector.source.timer;
+
+import org.apache.camel.kakfaconnector.ConnectorPropertyFactory;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.util.Properties;
+
+class CamelTimerPropertyFactory implements ConnectorPropertyFactory {
+    private final int tasksMax;
+    private final String topic;
+    private int repeatCount;
+
+    public CamelTimerPropertyFactory(int tasksMax, String topic, int repeatCount) {
+        this.tasksMax = tasksMax;
+        this.topic = topic;
+        this.repeatCount = repeatCount;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties connectorProps = new Properties();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelSourceConnector");
+        connectorProps.put("tasks.max", String.valueOf(tasksMax));
+
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put("camel.source.url", String.format("timer:kafkaconnector?repeatCount=%d", repeatCount));
+        connectorProps.put("camel.source.kafka.topic", topic);
+
+        return connectorProps;
+    }
+}

--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+appender.file.type = File
+appender.file.name = file
+appender.file.fileName = target/tests.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+appender.out.type = Console
+appender.out.name = out
+appender.out.layout.type = PatternLayout
+appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+rootLogger.level = DEBUG
+rootLogger.appenderRef.file.ref = file

--- a/tests/src/test/resources/org/apache/camel/kakfaconnector/Dockerfile
+++ b/tests/src/test/resources/org/apache/camel/kakfaconnector/Dockerfile
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+FROM registry.access.redhat.com/ubi8/ubi-minimal as artemis-base
+MAINTAINER Otavio Rodolfo Piske <angusyoung@gmail.com>
+ARG ARTEMIS_VERSION
+ENV ARTEMIS_VERSION ${ARTEMIS_VERSION:-2.7.0}
+ARG ARTEMIS_JOURNAL
+ENV ARTEMIS_JOURNAL ${ARTEMIS_JOURNAL:-aio}
+ENV JMS_BROKER_ROOT /opt/camel-kafka-connector/artemis/
+EXPOSE 1883 5672 8161 61616
+RUN microdnf install -y java-1.8.0-openjdk-headless libaio tar gzip && microdnf clean all
+ENV JAVA_HOME /etc/alternatives/jre
+RUN mkdir -p ${JMS_BROKER_ROOT}
+WORKDIR ${JMS_BROKER_ROOT}
+RUN curl https://archive.apache.org/dist/activemq/activemq-artemis/${ARTEMIS_VERSION}/apache-artemis-${ARTEMIS_VERSION}-bin.tar.gz -o apache-artemis.tar.gz && \
+    mkdir -p apache-artemis && tar --strip-components=1 -xvf apache-artemis.tar.gz -C apache-artemis && \
+    rm -f apache-artemis.tar.gz
+
+FROM artemis-base as artemis
+RUN ${JMS_BROKER_ROOT}/apache-artemis/bin/artemis create --${ARTEMIS_JOURNAL} --relax-jolokia --allow-anonymous --http-host 0.0.0.0 --user admin --password "admin" --role amq --data /artemis-storage ${JMS_BROKER_ROOT}/apache-artemis-instance
+CMD [ "sh", "-c", "./apache-artemis-instance/bin/artemis run" ]


### PR DESCRIPTION
The patch wraps an Apache Artemis broker instance using TestContainers and uses it to connect to the embeddable Kafka Connect Runtime to consume and produce data via through Kafka via JMS.

At the moment, it only tests the basic/send receive functionality via Openwire protocol, but the code should be extensible to add more tests of those. 