### PR TITLE
Integration tests: AWS SQS Sink

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,14 @@ For more information about Kafka Connect take a look http://kafka.apache.org/doc
 mvn clean package
 ----
 
+=== Build the project and run integration tests
+
+To run the integration tests it's necessary to have Docker installed.
+
+----
+mvn clean verify package
+----
+
 === Try it out locally
 
 You can use Camel Kafka connectors with local Apache Kafka installation.

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
@@ -17,6 +17,7 @@
 package org.apache.camel.kafkaconnector;
 
 import org.apache.camel.Exchange;
+
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.kafkaconnector.utils.CamelMainSupport;
 import org.apache.camel.support.DefaultExchange;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -221,11 +221,19 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>localstack</artifactId>
+                <version>${version.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-hl7</artifactId>
                 <version>${camel.version}</version>
                 <scope>test</scope>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>kafka</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/AWSConfigs.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/AWSConfigs.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kafkaconnector;
+
+
+import java.util.Properties;
+
+public class AWSConfigs {
+    public static final String ACCESS_KEY = "access.key";
+    public static final String SECRET_KEY = "secret.key";
+    public static final String REGION = "aws.region";
+    public static final String AMAZON_AWS_HOST = "aws.host";
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
@@ -19,6 +19,7 @@
 package org.apache.camel.kafkaconnector;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +48,33 @@ public class ContainerUtil {
                 retries--;
             }
             else {
+                break;
+            }
+        } while (retries > 0);
+    }
+
+    /**
+     * Wait for the container to be in running state
+     * @param container the container to wait for
+     */
+    public static void waitForHttpInitialization(GenericContainer container, int port) {
+        int retries = 5;
+
+        do {
+            boolean state = container.isRunning();
+
+            if (state == false) {
+                try {
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+                } catch (InterruptedException e) {
+                    container.stop();
+                    fail("Test interrupted");
+                }
+
+                retries--;
+            }
+            else {
+                container.waitingFor(Wait.forHttp("/").forPort(port));
                 break;
             }
         } while (retries > 0);

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/KafkaConnectRunner.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/KafkaConnectRunner.java
@@ -125,6 +125,8 @@ public class KafkaConnectRunner {
 
     private void callTestErrorHandler(Properties connectorProps, Throwable error) {
         if (error != null) {
+            log.error("Failed to create the connector");
+            error.printStackTrace();
             TestCommon.failOnConnectorError(error, connectorProps,
                     (String) connectorProps.get(ConnectorConfig.NAME_CONFIG));
         }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
@@ -43,6 +43,11 @@ public final class TestCommon {
      */
     public static final String DEFAULT_JMS_QUEUE = "ckc.queue";
 
+    /**
+     * The default JMS queue name used during the tests
+     */
+    public static final String DEFAULT_SQS_QUEUE = "ckc";
+
 
     public static void failOnConnectorError(Throwable error, Properties connectorProps, String name) {
         log.error("Failed to create job for {} with properties", name, connectorProps,

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kafkaconnector.sink.aws.sqs;
+
+import org.apache.camel.kafkaconnector.AWSConfigs;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+import java.util.Properties;
+
+
+/**
+ * Creates the set of properties used by a Camel JMS Sink Connector
+ */
+class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
+    private final int tasksMax;
+    private final String topic;
+    private final String queue;
+    private final Properties amazonConfigs;
+
+
+    CamelAWSSQSPropertyFactory(int tasksMax, String topic, String queue, Properties amazonConfigs) {
+        this.tasksMax = tasksMax;
+        this.topic = topic;
+        this.queue = queue;
+        this.amazonConfigs = amazonConfigs;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties connectorProps = new Properties();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSSQSSinkConnector");
+        connectorProps.put("tasks.max", String.valueOf(tasksMax));
+
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+
+        String queueUrl = "aws-sqs://" + queue + "?autoCreateQueue=false&accessKey=accesskey&protocol=http&amazonAWSHost=" +
+                amazonConfigs.getProperty(AWSConfigs.AMAZON_AWS_HOST, "localhost");
+        System.out.println("Queue URL => " + queueUrl);
+        connectorProps.put("camel.sink.url", queueUrl);
+        connectorProps.put("topics", topic);
+
+        connectorProps.put("camel.component.aws-sqs.configuration.access-key",
+                amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
+        connectorProps.put("camel.component.aws-sqs.configuration.secret-key",
+                amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
+
+        connectorProps.put("camel.component.aws-sqs.configuration.region",
+            amazonConfigs.getProperty(AWSConfigs.REGION, ""));
+
+        return connectorProps;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelSinkAWSSQSITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelSinkAWSSQSITCase.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.camel.kafkaconnector.sink.aws.sqs;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import org.apache.camel.kafkaconnector.AWSConfigs;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kafkaconnector.ContainerUtil;
+import org.apache.camel.kafkaconnector.KafkaConnectRunner;
+import org.apache.camel.kafkaconnector.TestCommon;
+import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+@Ignore("This test requires camel > 3.0.0-M4")
+public class CamelSinkAWSSQSITCase {
+    private static final Logger log = LoggerFactory.getLogger(CamelSinkAWSSQSITCase.class);
+    private static final int SQS_PORT = 4576;
+
+    @Rule
+    public KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+
+    @Rule
+    public LocalStackContainer localStackContainer = new LocalStackContainer()
+            .withServices(LocalStackContainer.Service.SQS);
+
+    private KafkaConnectRunner kafkaConnectRunner;
+    private AmazonSQS sqs;
+
+    private volatile int received = 0;
+    private final int expect = 10;
+
+    @Before
+    public void setUp() {
+        ContainerUtil.waitForInitialization(kafka);
+        log.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
+
+        log.info("Waiting for SQS initialization");
+        ContainerUtil.waitForHttpInitialization(localStackContainer, localStackContainer.getMappedPort(SQS_PORT));
+        log.info("SQS Initialized");
+
+        final String sqsInstance = localStackContainer
+                .getEndpointConfiguration(LocalStackContainer.Service.SQS)
+                .getServiceEndpoint();
+
+        log.info("SQS instance running at {}", sqsInstance);
+
+        Properties properties = new Properties();
+
+        properties.put(AWSConfigs.AMAZON_AWS_HOST, "localhost:" + localStackContainer.getMappedPort(SQS_PORT));
+
+        AWSCredentials credentials = localStackContainer.getDefaultCredentialsProvider().getCredentials();
+
+        properties.put(AWSConfigs.ACCESS_KEY, credentials.getAWSAccessKeyId());
+        properties.put(AWSConfigs.SECRET_KEY, credentials.getAWSSecretKey());
+        properties.put(AWSConfigs.REGION, Regions.US_EAST_1.name());
+
+        ConnectorPropertyFactory testProperties = new CamelAWSSQSPropertyFactory(1,
+            TestCommon.DEFAULT_TEST_TOPIC, TestCommon.DEFAULT_SQS_QUEUE, properties);
+
+        kafkaConnectRunner =  new KafkaConnectRunner(kafka.getBootstrapServers());
+        kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
+
+        sqs = AmazonSQSClientBuilder
+                .standard()
+                .withEndpointConfiguration(localStackContainer
+                        .getEndpointConfiguration(LocalStackContainer.Service.SQS))
+                .withCredentials(localStackContainer.getDefaultCredentialsProvider())
+                .build();
+    }
+
+
+
+    private void consumeMessages(CountDownLatch latch) {
+        try {
+            Map<String, String> queueAttributes = new HashMap<>();
+
+            CreateQueueRequest createFifoQueueRequest = new CreateQueueRequest(
+                    TestCommon.DEFAULT_SQS_QUEUE).withAttributes(queueAttributes);
+
+            String queueUrl = sqs.createQueue(createFifoQueueRequest)
+                    .getQueueUrl();
+
+            log.debug("Consuming messages from {}", queueUrl);
+
+            ReceiveMessageRequest request = new ReceiveMessageRequest(queueUrl)
+                    .withWaitTimeSeconds(10)
+                    .withMaxNumberOfMessages(1);
+
+            for (int i = 0; i < expect; i++) {
+                ReceiveMessageResult result = sqs.receiveMessage(request);
+
+                List<Message> messages = result.getMessages();
+                for (Message message : messages) {
+                    log.info("Received: {}", message.getBody());
+                    received++;
+                }
+
+            }
+        }
+        catch (Throwable t) {
+            log.error("Failed to consume messages: {}", t.getMessage(), t);
+            fail(t.getMessage());
+        }
+        finally {
+            latch.countDown();
+        }
+    }
+
+
+    @Test
+    public void testBasicSendReceive() {
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+
+            ExecutorService service = Executors.newFixedThreadPool(2);
+            service.submit(() -> kafkaConnectRunner.run());
+
+            log.debug("Creating the consumer ...");
+            service.submit(() -> consumeMessages(latch));
+
+            KafkaClient<String,String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+
+            for (int i = 0; i < expect; i++) {
+                kafkaClient.produce(TestCommon.DEFAULT_TEST_TOPIC, "Sink test message " + i);
+            }
+
+            log.debug("Created the consumer ... About to receive messages");
+
+            if (latch.await(120, TimeUnit.SECONDS)) {
+                Assert.assertTrue("Didn't process the expected amount of messages: " + received + " != " + expect,
+                        received == expect);
+            }
+            else {
+                fail("Failed to receive the messages within the specified time");
+            }
+
+            kafkaConnectRunner.stop();
+        } catch (Exception e) {
+            log.error("Amazon SQS test failed: {}", e.getMessage(), e);
+            fail(e.getMessage());
+        }
+
+    }
+}

--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -19,10 +19,19 @@ appender.file.type = File
 appender.file.name = file
 appender.file.fileName = target/tests.log
 appender.file.layout.type = PatternLayout
-appender.file.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %m%n
+appender.file.layout.pattern = %d [%-15.15t] %p %c - %m%n
 appender.out.type = Console
 appender.out.name = out
 appender.out.layout.type = PatternLayout
 appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+
 rootLogger.level = DEBUG
 rootLogger.appenderRef.file.ref = file
+
+logger.reflections.name = org.reflections
+logger.reflections.level = FATAL
+logger.reflections.appenderRef.file.ref = file
+
+logger.camel-aws.name = org.apache.camel.component.aws.sqs
+logger.camel-aws.level  = TRACE
+logger.camel-aws.appenderRef.file.ref = file


### PR DESCRIPTION
Sending another set of integration tests, this time for AWS SQS Sink. Pretty much the same stuff as before: Kafka and Local Stack running from test containers, along with custom producers/consumers. 

This test depends on a widely available version of Camel 3 with the following patch:

- https://github.com/apache/camel/commit/034180d93374892ddbedc6b0e254542b6c2a5ffe
- https://github.com/apache/camel/commit/3971b22485de762f910068916dc12323f05904c3

They have been added to Camel master, but I think there's no recent snapshot with them yet. That is why the test is marked as Ignore.