### PR TITLE
Re-enable the AWS SQS test 

### DIFF
--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelSinkAWSSQSITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelSinkAWSSQSITCase.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.fail;
 
-@Ignore("This test requires camel > 3.0.0-M4")
 public class CamelSinkAWSSQSITCase {
     private static final Logger log = LoggerFactory.getLogger(CamelSinkAWSSQSITCase.class);
     private static final int SQS_PORT = 4576;


### PR DESCRIPTION
Since Camel 3 RC2 is released with the fix required for the test execution, we can enable this one.