### PR TITLE
Fix source check violations

### DIFF
--- a/core/src/main/assembly/package.xml
+++ b/core/src/main/assembly/package.xml
@@ -1,3 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkConnector.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,54 +16,53 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 public class CamelSinkConnector extends SinkConnector {
-   private static Logger log = LoggerFactory.getLogger(CamelSinkConnector.class);
+    private static Logger log = LoggerFactory.getLogger(CamelSinkConnector.class);
 
-   private Map<String, String> configProps;
+    private Map<String, String> configProps;
 
-   @Override
-   public String version() {
-      return VersionUtil.getVersion();
-   }
+    @Override
+    public String version() {
+        return VersionUtil.getVersion();
+    }
 
-   @Override
-   public void start(Map<String, String> configProps) {
-      log.info("Connector config keys: {}", String.join(", ", configProps.keySet()));
-      this.configProps = configProps;
-   }
+    @Override
+    public void start(Map<String, String> configProps) {
+        log.info("Connector config keys: {}", String.join(", ", configProps.keySet()));
+        this.configProps = configProps;
+    }
 
-   @Override
-   public Class<? extends Task> taskClass() {
-      return CamelSinkTask.class;
-   }
+    @Override
+    public Class<? extends Task> taskClass() {
+        return CamelSinkTask.class;
+    }
 
-   @Override
-   public List<Map<String, String>> taskConfigs(int maxTasks) {
-      log.info("Setting task configurations for {} workers.", maxTasks);
-      final List<Map<String, String>> configs = new ArrayList<>(maxTasks);
-      for (int i = 0; i < maxTasks; ++i) {
-         configs.add(configProps);
-      }
-      return configs;
-   }
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        log.info("Setting task configurations for {} workers.", maxTasks);
+        final List<Map<String, String>> configs = new ArrayList<>(maxTasks);
+        for (int i = 0; i < maxTasks; ++i) {
+            configs.add(configProps);
+        }
+        return configs;
+    }
 
-   @Override
-   public void stop() {
-      //nothing to do
-   }
+    @Override
+    public void stop() {
+        //nothing to do
+    }
 
-   @Override
-   public ConfigDef config() {
-      return CamelSinkConnectorConfig.conf();
-   }
+    @Override
+    public ConfigDef config() {
+        return CamelSinkConnectorConfig.conf();
+    }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkConnectorConfig.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkConnectorConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,33 +16,33 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 
-import java.util.Map;
-
 public class CamelSinkConnectorConfig extends AbstractConfig {
-   public static final String CAMEL_SINK_URL_DEFAULT = "log:kafkaconnector?showAll=true";
-   public static final String CAMEL_SINK_URL_CONF = "camel.sink.url";
-   private static final String CAMEL_SINK_URL_DOC = "The camel url to configure the destination";
+    public static final String CAMEL_SINK_URL_DEFAULT = "log:kafkaconnector?showAll=true";
+    public static final String CAMEL_SINK_URL_CONF = "camel.sink.url";
 
-   public static final String CAMEL_SINK_MARSHAL_DEFAULT = null;
-   public static final String CAMEL_SINK_MARSHAL_CONF = "camel.sink.marshal";
-   private static final String CAMEL_SINK_MARSHAL_DOC = "The camel dataformat name to use to marshal data to the destination";
+    public static final String CAMEL_SINK_MARSHAL_DEFAULT = null;
+    public static final String CAMEL_SINK_MARSHAL_CONF = "camel.sink.marshal";
 
-   public CamelSinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
-      super(config, parsedConfig);
-   }
+    private static final String CAMEL_SINK_URL_DOC = "The camel url to configure the destination";
+    private static final String CAMEL_SINK_MARSHAL_DOC = "The camel dataformat name to use to marshal data to the destination";
 
-   public CamelSinkConnectorConfig(Map<String, String> parsedConfig) {
-      this(conf(), parsedConfig);
-   }
+    public CamelSinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
+        super(config, parsedConfig);
+    }
 
-   public static ConfigDef conf() {
-      return new ConfigDef()
-            .define(CAMEL_SINK_URL_CONF, Type.STRING, CAMEL_SINK_URL_DEFAULT, Importance.HIGH, CAMEL_SINK_URL_DOC)
-            .define(CAMEL_SINK_MARSHAL_CONF, Type.STRING, CAMEL_SINK_MARSHAL_DEFAULT, Importance.HIGH, CAMEL_SINK_MARSHAL_DOC);
-   }
+    public CamelSinkConnectorConfig(Map<String, String> parsedConfig) {
+        this(conf(), parsedConfig);
+    }
+
+    public static ConfigDef conf() {
+        return new ConfigDef()
+                .define(CAMEL_SINK_URL_CONF, Type.STRING, CAMEL_SINK_URL_DEFAULT, Importance.HIGH, CAMEL_SINK_URL_DOC)
+                .define(CAMEL_SINK_MARSHAL_CONF, Type.STRING, CAMEL_SINK_MARSHAL_DEFAULT, Importance.HIGH, CAMEL_SINK_MARSHAL_DOC);
+    }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,8 +16,11 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import org.apache.camel.Exchange;
-
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.kafkaconnector.utils.CamelMainSupport;
 import org.apache.camel.support.DefaultExchange;
@@ -29,15 +32,11 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 public class CamelSinkTask extends SinkTask {
+    public static final String KAFKA_RECORD_KEY_HEADER = "camel.kafka.connector.record.key";
+
     private static Logger log = LoggerFactory.getLogger(CamelSinkTask.class);
 
-    public static final String KAFKA_RECORD_KEY_HEADER = "camel.kafka.connector.record.key";
     private static final String LOCAL_URL = "direct:start";
     private static final String HEADER_CAMEL_PREFIX = "CamelHeader";
     private static final String PROPERTY_CAMEL_PREFIX = "CamelProperty";
@@ -112,17 +111,17 @@ public class CamelSinkTask extends SinkTask {
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT32_SCHEMA.type().getName())) {
             map.put(singleHeader.key(), singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.BYTES_SCHEMA.type().getName())) {
-            map.put(singleHeader.key(), ((byte[])singleHeader.value()));
+            map.put(singleHeader.key(), (byte[])singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.FLOAT32_SCHEMA.type().getName())) {
-            map.put(singleHeader.key(), ((float)singleHeader.value()));
+            map.put(singleHeader.key(), (float)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.FLOAT64_SCHEMA.type().getName())) {
-            map.put(singleHeader.key(), ((double)singleHeader.value()));
+            map.put(singleHeader.key(), (double)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT16_SCHEMA.type().getName())) {
-            map.put(singleHeader.key(), ((short)singleHeader.value()));
+            map.put(singleHeader.key(), (short)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT64_SCHEMA.type().getName())) {
-            map.put(singleHeader.key(), ((long)singleHeader.value()));
+            map.put(singleHeader.key(), (long)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT8_SCHEMA.type().getName())) {
-            map.put(singleHeader.key(), ((byte)singleHeader.value()));
+            map.put(singleHeader.key(), (byte)singleHeader.value());
         }
     }
 
@@ -135,17 +134,17 @@ public class CamelSinkTask extends SinkTask {
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT32_SCHEMA.type().getName())) {
             exchange.getProperties().put(singleHeader.key(), singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.BYTES_SCHEMA.type().getName())) {
-            exchange.getProperties().put(singleHeader.key(), ((byte[])singleHeader.value()));
+            exchange.getProperties().put(singleHeader.key(), (byte[])singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.FLOAT32_SCHEMA.type().getName())) {
-            exchange.getProperties().put(singleHeader.key(), ((float)singleHeader.value()));
+            exchange.getProperties().put(singleHeader.key(), (float)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.FLOAT64_SCHEMA.type().getName())) {
-            exchange.getProperties().put(singleHeader.key(), ((double)singleHeader.value()));
+            exchange.getProperties().put(singleHeader.key(), (double)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT16_SCHEMA.type().getName())) {
-            exchange.getProperties().put(singleHeader.key(), ((short)singleHeader.value()));
+            exchange.getProperties().put(singleHeader.key(), (short)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT64_SCHEMA.type().getName())) {
-            exchange.getProperties().put(singleHeader.key(), ((long)singleHeader.value()));
+            exchange.getProperties().put(singleHeader.key(), (long)singleHeader.value());
         } else if (schema.type().getName().equalsIgnoreCase(Schema.INT8_SCHEMA.type().getName())) {
-            exchange.getProperties().put(singleHeader.key(), ((byte)singleHeader.value()));
+            exchange.getProperties().put(singleHeader.key(), (byte)singleHeader.value());
         }
     }
 

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceConnector.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,18 +16,17 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 public class CamelSourceConnector extends SourceConnector {
-    private static final Logger log = LoggerFactory.getLogger(CamelSourceConnector.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSourceConnector.class);
 
     private Map<String, String> configProps;
 
@@ -38,7 +37,7 @@ public class CamelSourceConnector extends SourceConnector {
 
     @Override
     public void start(Map<String, String> configProps) {
-        log.info("Connector config keys: {}", String.join(", ", configProps.keySet()));
+        LOG.info("Connector config keys: {}", String.join(", ", configProps.keySet()));
         this.configProps = configProps;
     }
 
@@ -49,7 +48,7 @@ public class CamelSourceConnector extends SourceConnector {
 
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
-        log.info("Setting task configurations for {} workers.", maxTasks);
+        LOG.info("Setting task configurations for {} workers.", maxTasks);
         final List<Map<String, String>> configs = new ArrayList<>(maxTasks);
         for (int i = 0; i < maxTasks; ++i) {
             configs.add(configProps);

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceConnectorConfig.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceConnectorConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,64 +16,64 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 
-import java.util.Map;
-
 public class CamelSourceConnectorConfig extends AbstractConfig {
+    public static final String CAMEL_SOURCE_URL_DEFAULT = "timer:kafkaconnector";
+    public static final String CAMEL_SOURCE_URL_CONF = "camel.source.url";
 
-   public static final String CAMEL_SOURCE_URL_DEFAULT = "timer:kafkaconnector";
-   public static final String CAMEL_SOURCE_URL_CONF = "camel.source.url";
-   private static final String CAMEL_SOURCE_URL_DOC = "The camel url to configure the source";
+    public static final String CAMEL_SOURCE_UNMARSHAL_DEFAULT = null;
+    public static final String CAMEL_SOURCE_UNMARSHAL_CONF = "camel.source.unmarshal";
 
-   public static final String CAMEL_SOURCE_UNMARSHAL_DEFAULT = null;
-   public static final String CAMEL_SOURCE_UNMARSHAL_CONF = "camel.source.unmarshal";
-   private static final String CAMEL_SOURCE_UNMARSHAL_DOC = "The camel dataformat name to use to unmarshal data from the source";
+    public static final String TOPIC_DEFAULT = "test";
+    public static final String TOPIC_CONF = "camel.source.kafka.topic";
 
-   public static final String TOPIC_DEFAULT = "test";
-   public static final String TOPIC_CONF = "camel.source.kafka.topic";
-   private static final String TOPIC_DOC = "The topic to publish data to";
+    public static final Long CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DEFAULT = 1000L;
+    public static final String CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_CONF = "camel.source.maxBatchPollSize";
 
-   public static final Long CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DEFAULT = 1000L;
-   public static final String CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_CONF = "camel.source.maxBatchPollSize";
-   private static final String CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DOC = "The max number of messages retrieved in a single poll()";
+    public static final Long CAMEL_SOURCE_MAX_POLL_DURATION_DEFAULT = 1000L;
+    public static final String CAMEL_SOURCE_MAX_POLL_DURATION_CONF = "camel.source.maxPollDuration";
 
-   public static final Long CAMEL_SOURCE_MAX_POLL_DURATION_DEFAULT = 1000L;
-   public static final String CAMEL_SOURCE_MAX_POLL_DURATION_CONF = "camel.source.maxPollDuration";
-   private static final String CAMEL_SOURCE_MAX_POLL_DURATION_DOC = "The maximum time in milliseconds spent in a single call to poll()";
+    public static final Long CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DEFAULT = 1000L;
+    public static final String CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_CONF = "camel.source.pollingConsumerQueueSize";
 
-   public static final Long CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DEFAULT = 1000L;
-   public static final String CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_CONF = "camel.source.pollingConsumerQueueSize";
-   private static final String CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DOC = "The queue size for the internal hand-off queue between the polling consumer, and producers sending data into the queue.";
+    public static final Long CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DEFAULT = 0L;
+    public static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_CONF = "camel.source.pollingConsumerBlockTimeout";
 
-   public static final Long CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DEFAULT = 0L;
-   public static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_CONF = "camel.source.pollingConsumerBlockTimeout";
-   private static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DOC = "To use a timeout (in milliseconds) when the producer is blocked if the internal queue is full. If the value is 0 or negative then no timeout is in use.";
+    public static final Boolean CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT = true;
+    public static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF = "camel.source.pollingConsumerBlockWhenFull";
 
-   public static final Boolean CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT = true;
-   public static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF = "camel.source.pollingConsumerBlockWhenFull";
-   private static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC = " Whether to block any producer if the internal queue is full.";
+    private static final String CAMEL_SOURCE_URL_DOC = "The camel url to configure the source";
+    private static final String CAMEL_SOURCE_UNMARSHAL_DOC = "The camel dataformat name to use to unmarshal data from the source";
+    private static final String TOPIC_DOC = "The topic to publish data to";
+    private static final String CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DOC = "The max number of messages retrieved in a single poll()";
+    private static final String CAMEL_SOURCE_MAX_POLL_DURATION_DOC = "The maximum time in milliseconds spent in a single call to poll()";
+    private static final String CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DOC = "The queue size for the internal hand-off queue between the polling consumer, and producers sending data into the queue.";
+    private static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DOC = "To use a timeout (in milliseconds) when the producer is blocked if the internal queue is full. If the value is 0 or negative then no timeout is in use.";
+    private static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC = " Whether to block any producer if the internal queue is full.";
 
-   public CamelSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
-      super(config, parsedConfig);
-   }
 
-   public CamelSourceConnectorConfig(Map<String, String> parsedConfig) {
-      this(conf(), parsedConfig);
-   }
+    public CamelSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
+        super(config, parsedConfig);
+    }
 
-   public static ConfigDef conf() {
-      return new ConfigDef()
-            .define(CAMEL_SOURCE_URL_CONF, Type.STRING, CAMEL_SOURCE_URL_DEFAULT, Importance.HIGH, CAMEL_SOURCE_URL_DOC)
-            .define(CAMEL_SOURCE_UNMARSHAL_CONF, Type.STRING, CAMEL_SOURCE_UNMARSHAL_DEFAULT, Importance.HIGH, CAMEL_SOURCE_UNMARSHAL_DOC)
-            .define(TOPIC_CONF, ConfigDef.Type.STRING, TOPIC_DEFAULT, ConfigDef.Importance.HIGH, TOPIC_DOC)
-            .define(CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_CONF, Type.LONG, CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DOC)
-            .define(CAMEL_SOURCE_MAX_POLL_DURATION_CONF, Type.LONG, CAMEL_SOURCE_MAX_POLL_DURATION_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_MAX_POLL_DURATION_DOC)
-            .define(CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_CONF, Type.LONG, CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DOC)
-            .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_CONF, Type.LONG, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DOC)
-            .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF, Type.BOOLEAN, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC);
-   }
+    public CamelSourceConnectorConfig(Map<String, String> parsedConfig) {
+        this(conf(), parsedConfig);
+    }
+
+    public static ConfigDef conf() {
+        return new ConfigDef()
+                .define(CAMEL_SOURCE_URL_CONF, Type.STRING, CAMEL_SOURCE_URL_DEFAULT, Importance.HIGH, CAMEL_SOURCE_URL_DOC)
+                .define(CAMEL_SOURCE_UNMARSHAL_CONF, Type.STRING, CAMEL_SOURCE_UNMARSHAL_DEFAULT, Importance.HIGH, CAMEL_SOURCE_UNMARSHAL_DOC)
+                .define(TOPIC_CONF, ConfigDef.Type.STRING, TOPIC_DEFAULT, ConfigDef.Importance.HIGH, TOPIC_DOC)
+                .define(CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_CONF, Type.LONG, CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_DOC)
+                .define(CAMEL_SOURCE_MAX_POLL_DURATION_CONF, Type.LONG, CAMEL_SOURCE_MAX_POLL_DURATION_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_MAX_POLL_DURATION_DOC)
+                .define(CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_CONF, Type.LONG, CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DOC)
+                .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_CONF, Type.LONG, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DOC)
+                .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF, Type.BOOLEAN, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC);
+    }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,6 +16,16 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.PollingConsumer;
@@ -27,19 +37,8 @@ import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigDecimal;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 public class CamelSourceTask extends SourceTask {
-    private static final Logger log = LoggerFactory.getLogger(CamelSourceTask.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSourceTask.class);
 
     private static final String LOCAL_URL = "direct:end";
     private static final String HEADER_CAMEL_PREFIX = "CamelHeader";
@@ -60,7 +59,7 @@ public class CamelSourceTask extends SourceTask {
     @Override
     public void start(Map<String, String> props) {
         try {
-            log.info("Starting CamelSourceTask connector task");
+            LOG.info("Starting CamelSourceTask connector task");
             config = new CamelSourceConnectorConfig(props);
 
             maxBatchPollSize = config.getLong(CamelSourceConnectorConfig.CAMEL_SOURCE_MAX_BATCH_POLL_SIZE_CONF);
@@ -79,7 +78,7 @@ public class CamelSourceTask extends SourceTask {
             consumer.start();
             
             cms.start();
-            log.info("CamelSourceTask connector task started");
+            LOG.info("CamelSourceTask connector task started");
         } catch (Exception e) {
             throw new ConnectException("Failed to create and start Camel context", e);
         }
@@ -92,17 +91,17 @@ public class CamelSourceTask extends SourceTask {
 
         List<SourceRecord> records = new ArrayList<>();
 
-        while (collectedRecords < maxBatchPollSize && (Instant.now().toEpochMilli()-startPollEpochMilli) < maxPollDuration) {
+        while (collectedRecords < maxBatchPollSize && (Instant.now().toEpochMilli() - startPollEpochMilli) < maxPollDuration) {
             Exchange exchange = consumer.receiveNoWait();
 
             if (exchange != null) {
-                log.debug("Received exchange with");
-                log.debug("\t from endpoint: {}", exchange.getFromEndpoint());
-                log.debug("\t exchange id: {}", exchange.getExchangeId());
-                log.debug("\t message id: {}", exchange.getMessage().getMessageId());
-                log.debug("\t message body: {}", exchange.getMessage().getBody());
-                log.debug("\t message headers: {}", exchange.getMessage().getHeaders());
-                log.debug("\t message properties: {}", exchange.getProperties());
+                LOG.debug("Received exchange with");
+                LOG.debug("\t from endpoint: {}", exchange.getFromEndpoint());
+                LOG.debug("\t exchange id: {}", exchange.getExchangeId());
+                LOG.debug("\t message id: {}", exchange.getMessage().getMessageId());
+                LOG.debug("\t message body: {}", exchange.getMessage().getBody());
+                LOG.debug("\t message headers: {}", exchange.getMessage().getHeaders());
+                LOG.debug("\t message properties: {}", exchange.getProperties());
 
                 // TODO: see if there is a better way to use sourcePartition an sourceOffset
                 Map<String, String> sourcePartition = Collections.singletonMap("filename", exchange.getFromEndpoint().toString());
@@ -131,18 +130,18 @@ public class CamelSourceTask extends SourceTask {
 
     @Override
     public void stop() {
-        log.info("Stopping CamelSourceTask connector task");
+        LOG.info("Stopping CamelSourceTask connector task");
         try {
             consumer.stop();
         } catch (Exception e) {
-            log.error("Error stopping camel consumer: {}", e.getMessage());
+            LOG.error("Error stopping camel consumer: {}", e.getMessage());
         }
         try {
             cms.stop();
         } catch (Exception e) {
             throw new ConnectException("Failed to stop Camel context", e);
         } finally {
-            log.info("CamelSourceTask connector task stopped");
+            LOG.info("CamelSourceTask connector task stopped");
         }
     }
 
@@ -185,11 +184,12 @@ public class CamelSourceTask extends SourceTask {
         }
     }
 
-    private String getLocalUrlWithPollingOptions(CamelSourceConnectorConfig config){
+    private String getLocalUrlWithPollingOptions(CamelSourceConnectorConfig config) {
         long pollingConsumerQueueSize = config.getLong(CamelSourceConnectorConfig.CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_CONF);
         long pollingConsumerBlockTimeout = config.getLong(CamelSourceConnectorConfig.CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_CONF);
         boolean pollingConsumerBlockWhenFull = config.getBoolean(CamelSourceConnectorConfig.CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF);
-        return LOCAL_URL + "?pollingConsumerQueueSize=" +pollingConsumerQueueSize+"&pollingConsumerBlockTimeout="+pollingConsumerBlockTimeout+"&pollingConsumerBlockWhenFull="+pollingConsumerBlockWhenFull;
+        return LOCAL_URL + "?pollingConsumerQueueSize=" + pollingConsumerQueueSize + "&pollingConsumerBlockTimeout="
+                + pollingConsumerBlockTimeout + "&pollingConsumerBlockWhenFull=" + pollingConsumerBlockWhenFull;
     }
 
     public CamelMainSupport getCms() {

--- a/core/src/main/java/org/apache/camel/kafkaconnector/VersionUtil.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/VersionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,12 +16,16 @@
  */
 package org.apache.camel.kafkaconnector;
 
-class VersionUtil {
-   public static String getVersion() {
-      try {
-         return VersionUtil.class.getPackage().getImplementationVersion();
-      } catch (Exception ex) {
-         return "0.0.0.0";
-      }
-   }
+final class VersionUtil {
+
+    private VersionUtil() {
+    }
+
+    public static String getVersion() {
+        try {
+            return VersionUtil.class.getPackage().getImplementationVersion();
+        } catch (Exception ex) {
+            return "0.0.0.0";
+        }
+    }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/converters/S3ObjectConverter.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/converters/S3ObjectConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -17,29 +17,27 @@
 package org.apache.camel.kafkaconnector.converters;
 
 import java.util.Map;
-
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.storage.Converter;
 
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
-
 public class S3ObjectConverter implements Converter {
 
-	private final S3ObjectSerializer serializer = new S3ObjectSerializer();
+    private final S3ObjectSerializer serializer = new S3ObjectSerializer();
 
-	@Override
-	public void configure(Map<String, ?> arg0, boolean arg1) {
-	}
+    @Override
+    public void configure(Map<String, ?> arg0, boolean arg1) {
+    }
 
-	@Override
-	public byte[] fromConnectData(String topic, Schema schema, Object value) {
-		return serializer.serialize(topic, (S3ObjectInputStream) value);
-	}
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        return serializer.serialize(topic, (S3ObjectInputStream) value);
+    }
 
-	@Override
-	public SchemaAndValue toConnectData(String arg0, byte[] arg1) {
-		return null;
-	}
+    @Override
+    public SchemaAndValue toConnectData(String arg0, byte[] arg1) {
+        return null;
+    }
 
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/converters/S3ObjectSerializer.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/converters/S3ObjectSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -20,38 +20,36 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
-
-import org.apache.kafka.common.serialization.Serializer;
-
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.kafka.common.serialization.Serializer;
 
 public class S3ObjectSerializer implements Serializer<S3ObjectInputStream> {
 
-	@Override
-	public void configure(Map<String, ?> configs, boolean isKey) {
-	}
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
 
-	@Override
-	public byte[] serialize(String topic, S3ObjectInputStream data) {
-		InputStream is = data.getDelegateStream();
-		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    @Override
+    public byte[] serialize(String topic, S3ObjectInputStream data) {
+        InputStream is = data.getDelegateStream();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
-		int nRead;
-		byte[] byteArray = new byte[16384];
+        int nRead;
+        byte[] byteArray = new byte[16384];
 
-		try {
-			while ((nRead = is.read(byteArray, 0, byteArray.length)) != -1) {
-				buffer.write(byteArray, 0, nRead);
-			}
-		} catch (IOException e1) {
-			e1.printStackTrace();
-		}
+        try {
+            while ((nRead = is.read(byteArray, 0, byteArray.length)) != -1) {
+                buffer.write(byteArray, 0, nRead);
+            }
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        }
 
-		return buffer.toByteArray();
-	}
+        return buffer.toByteArray();
+    }
 
-	@Override
-	public void close() {
-	}
+    @Override
+    public void close() {
+    }
 
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelMainSupport.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelMainSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,6 +16,13 @@
  */
 package org.apache.camel.kafkaconnector.utils;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.ConsumerTemplate;
@@ -33,14 +40,6 @@ import org.apache.camel.util.OrderedProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 public class CamelMainSupport {
     private static Logger log = LoggerFactory.getLogger(CamelMainSupport.class);
 
@@ -55,12 +54,13 @@ public class CamelMainSupport {
     }
 
     public CamelMainSupport(Map<String, String> props, String fromUrl, String toUrl, String marshal, String unmarshal, CamelContext camelContext) throws Exception {
-        this.camel = camelContext;//new DefaultCamelContext();
+        this.camel = camelContext; //new DefaultCamelContext();
         camelMain = new Main() {
             @Override
             protected ProducerTemplate findOrCreateCamelTemplate() {
                 return camel.createProducerTemplate();
             }
+
             @Override
             protected CamelContext createCamelContext() {
                 return camel;
@@ -72,11 +72,11 @@ public class CamelMainSupport {
         // reordering properties to place the one starting with "#class:" first
         Map<String, String> orderedProps = new LinkedHashMap<>();
         props.keySet().stream()
-                .filter( k -> props.get(k).startsWith("#class:"))
-                .forEach( k -> orderedProps.put(k, props.get(k)));
+                .filter(k -> props.get(k).startsWith("#class:"))
+                .forEach(k -> orderedProps.put(k, props.get(k)));
         props.keySet().stream()
-                .filter( k -> !props.get(k).startsWith("#class:"))
-                .forEach( k -> orderedProps.put(k, props.get(k)));
+                .filter(k -> !props.get(k).startsWith("#class:"))
+                .forEach(k -> orderedProps.put(k, props.get(k)));
 
         Properties camelProperties = new OrderedProperties();
         camelProperties.putAll(orderedProps);
@@ -88,13 +88,13 @@ public class CamelMainSupport {
         this.camel.addRoutes(new RouteBuilder() {
             public void configure() {
                 RouteDefinition rd = from(fromUrl);
-                if(marshal != null && unmarshal != null){
-                    throw new UnsupportedOperationException("Uses of both marshal (i.e. "+marshal+") and unmarshal (i.e. "+unmarshal+") is not supported");
-                } else if(marshal != null) {
+                if (marshal != null && unmarshal != null) {
+                    throw new UnsupportedOperationException("Uses of both marshal (i.e. " + marshal + ") and unmarshal (i.e. " + unmarshal + ") is not supported");
+                } else if (marshal != null) {
                     log.info("Creating Camel route from({}).marshal().custom({}).to({})", fromUrl, marshal, toUrl);
                     camel.getRegistry().bind(marshal, lookupAndInstantiateDataformat(marshal));
                     rd.marshal().custom(marshal);
-                } else if(unmarshal != null) {
+                } else if (unmarshal != null) {
                     log.info("Creating Camel route from({}).unmarshal().custom({}).to({})", fromUrl, unmarshal, toUrl);
                     camel.getRegistry().bind(unmarshal, lookupAndInstantiateDataformat(unmarshal));
                     rd.unmarshal().custom(unmarshal);
@@ -146,13 +146,13 @@ public class CamelMainSupport {
         return camel.createConsumerTemplate();
     }
 
-    private DataFormat lookupAndInstantiateDataformat(String dataformatName){
+    private DataFormat lookupAndInstantiateDataformat(String dataformatName) {
         DataFormat df = camel.resolveDataFormat(dataformatName);
 
-        if(df == null) {
+        if (df == null) {
             df = camel.createDataFormat(dataformatName);
 
-            final String prefix = "camel" + "." +  "dataformat" + "." + dataformatName + ".";
+            final String prefix = "camel" + "." + "dataformat" + "." + dataformatName + ".";
             final Properties props = camel.getPropertiesComponent().loadProperties(k -> k.startsWith(prefix));
 
             CamelContextAware.trySetCamelContext(df, camel);
@@ -169,7 +169,7 @@ public class CamelMainSupport {
         }
 
         //TODO: move it to the caller?
-        if(df == null){
+        if (df == null) {
             throw new UnsupportedOperationException("No DataFormat found with name " + dataformatName);
         }
         return df;
@@ -220,7 +220,7 @@ public class CamelMainSupport {
             }
         }
 
-        public boolean hasException()   {
+        public boolean hasException() {
             return startException != null;
         }
 

--- a/core/src/test/java/org/apache/camel/kafkaconnector/CamelSinkTaskTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/CamelSinkTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,23 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.kafkaconnector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+package org.apache.camel.kafkaconnector;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.camel.CamelContext;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.Exchange;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CamelSinkTaskTest {
 
@@ -135,7 +133,7 @@ public class CamelSinkTaskTest {
         Exchange exchange = c.receive("seda:test", 1000L);
         assertEquals("camel", exchange.getMessage().getBody());
         assertEquals("test", exchange.getMessage().getHeaders().get(CamelSinkTask.KAFKA_RECORD_KEY_HEADER));
-        assertTrue((boolean) exchange.getProperties().get(("CamelPropertyMyBoolean")));
+        assertTrue((boolean) exchange.getProperties().get("CamelPropertyMyBoolean"));
         assertEquals(myByte, (Byte) exchange.getProperties().get("CamelPropertyMyByte"));
         assertEquals(myFloat, (Float) exchange.getProperties().get("CamelPropertyMyFloat"));
         assertEquals(myShort, (Short) exchange.getProperties().get("CamelPropertyMyShort"));
@@ -186,7 +184,7 @@ public class CamelSinkTaskTest {
         Exchange exchange = c.receive("seda:test", 1000L);
         assertEquals("camel", exchange.getMessage().getBody());
         assertEquals("test", exchange.getMessage().getHeaders().get(CamelSinkTask.KAFKA_RECORD_KEY_HEADER));
-        assertTrue((boolean) exchange.getProperties().get(("CamelPropertyMyBoolean")));
+        assertTrue((boolean) exchange.getProperties().get("CamelPropertyMyBoolean"));
         assertEquals(myByte, (Byte) exchange.getProperties().get("CamelPropertyMyByte"));
         assertEquals(myFloat, (Float) exchange.getProperties().get("CamelPropertyMyFloat"));
         assertEquals(myShort, (Short) exchange.getProperties().get("CamelPropertyMyShort"));

--- a/core/src/test/java/org/apache/camel/kafkaconnector/CamelSourceTaskTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/CamelSourceTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,19 +16,18 @@
  */
 package org.apache.camel.kafkaconnector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CamelSourceTaskTest {
 
@@ -122,8 +121,8 @@ public class CamelSourceTaskTest {
         assertEquals(2, camelSourceTask.getCms().getEndpoints().size());
 
         camelSourceTask.getCms().getEndpoints().stream()
-                .filter( e -> e.getEndpointUri().startsWith("direct"))
-                .forEach( e -> assertEquals("direct://end?pollingConsumerBlockTimeout=1000&pollingConsumerBlockWhenFull=false&pollingConsumerQueueSize=10", e.getEndpointUri()));
+                .filter(e -> e.getEndpointUri().startsWith("direct"))
+                .forEach(e -> assertEquals("direct://end?pollingConsumerBlockTimeout=1000&pollingConsumerBlockWhenFull=false&pollingConsumerQueueSize=10", e.getEndpointUri()));
 
         camelSourceTask.stop();
     }

--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,18 +16,15 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.util.HashMap;
+import java.util.Map;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.camel.component.hl7.HL7DataFormat;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.kafkaconnector.utils.CamelMainSupport;
-import org.apache.camel.spi.DataFormat;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class DataFormatTest {
 
@@ -69,7 +66,7 @@ public class DataFormatTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testBothDataFormatConfiguredError() throws Exception {
-        new CamelMainSupport(new HashMap<String,String>(), "direct://start", "log://test", "syslog", "syslog");
+        new CamelMainSupport(new HashMap<>(), "direct://start", "log://test", "syslog", "syslog");
     }
 
     @Test

--- a/core/src/test/java/org/apache/camel/kafkaconnector/PropertiesOrderTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/PropertiesOrderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,20 +16,10 @@
  */
 package org.apache.camel.kafkaconnector;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.camel.ConsumerTemplate;
-import org.apache.camel.Exchange;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
 
 public class PropertiesOrderTest {
 

--- a/core/src/test/java/org/apache/camel/kafkaconnector/test/TestBlockingQueueFactory.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/test/TestBlockingQueueFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,15 +16,14 @@
  */
 package org.apache.camel.kafkaconnector.test;
 
+import java.util.concurrent.BlockingQueue;
 import org.apache.camel.component.seda.ArrayBlockingQueueFactory;
 import org.apache.camel.component.seda.BlockingQueueFactory;
 
-import java.util.concurrent.BlockingQueue;
-
 public class TestBlockingQueueFactory implements BlockingQueueFactory {
-    private Integer counter;
-
     BlockingQueueFactory bqf = new ArrayBlockingQueueFactory();
+
+    private Integer counter;
 
     public Integer getCounter() {
         return counter;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/AWSConfigs.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/AWSConfigs.java
@@ -6,24 +6,24 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;
 
 
-import java.util.Properties;
-
-public class AWSConfigs {
+public final class AWSConfigs {
     public static final String ACCESS_KEY = "access.key";
     public static final String SECRET_KEY = "secret.key";
     public static final String REGION = "aws.region";
     public static final String AMAZON_AWS_HOST = "aws.host";
+
+    private AWSConfigs() {
+    }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ArtemisContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ArtemisContainer.java
@@ -6,14 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;
@@ -39,7 +38,7 @@ public class ArtemisContainer extends GenericContainer {
                         "org/apache/camel/kafkaconnector/Dockerfile"));
 
         withExposedPorts(new Integer[]{DEFAULT_MQTT_PORT, DEFAULT_AMQP_PORT,
-                DEFAULT_ADMIN_PORT, DEFAULT_ACCEPTOR_PORT});
+            DEFAULT_ADMIN_PORT, DEFAULT_ACCEPTOR_PORT});
 
         waitingFor(Wait.forListeningPort());
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ConnectorPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ConnectorPropertyFactory.java
@@ -6,14 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
@@ -6,29 +6,31 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;
 
+import java.util.concurrent.TimeUnit;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.fail;
 
-public class ContainerUtil {
+public final class ContainerUtil {
+
+    private ContainerUtil() {
+    }
 
     /**
      * Wait for the container to be in running state
+     *
      * @param container the container to wait for
      */
     public static void waitForInitialization(GenericContainer container) {
@@ -37,7 +39,7 @@ public class ContainerUtil {
         do {
             boolean state = container.isRunning();
 
-            if (state == false) {
+            if (!state) {
                 try {
                     Thread.sleep(TimeUnit.SECONDS.toMillis(5));
                 } catch (InterruptedException e) {
@@ -46,8 +48,7 @@ public class ContainerUtil {
                 }
 
                 retries--;
-            }
-            else {
+            } else {
                 break;
             }
         } while (retries > 0);
@@ -55,6 +56,7 @@ public class ContainerUtil {
 
     /**
      * Wait for the container to be in running state
+     *
      * @param container the container to wait for
      */
     public static void waitForHttpInitialization(GenericContainer container, int port) {
@@ -63,7 +65,7 @@ public class ContainerUtil {
         do {
             boolean state = container.isRunning();
 
-            if (state == false) {
+            if (!state) {
                 try {
                     Thread.sleep(TimeUnit.SECONDS.toMillis(5));
                 } catch (InterruptedException e) {
@@ -72,8 +74,7 @@ public class ContainerUtil {
                 }
 
                 retries--;
-            }
-            else {
+            } else {
                 container.waitingFor(Wait.forHttp("/").forPort(port));
                 break;
             }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/DefaultKafkaConnectPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/DefaultKafkaConnectPropertyFactory.java
@@ -6,21 +6,19 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;
 
-import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
-
 import java.util.Properties;
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 
 
 /**

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/KafkaConnectPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/KafkaConnectPropertyFactory.java
@@ -6,14 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/KafkaConnectRunner.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/KafkaConnectRunner.java
@@ -6,17 +6,24 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static junit.framework.TestCase.fail;
 
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -36,20 +43,14 @@ import org.apache.kafka.connect.util.FutureCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
 
-import static junit.framework.TestCase.fail;
 
 /**
  * An embeddable Kafka Connect runtime for usage during the tests. It is equivalent
  * to the Kafka connect standalone CLI
  */
 public class KafkaConnectRunner {
-    private static final Logger log = LoggerFactory.getLogger(KafkaConnectRunner.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectRunner.class);
 
     private final String bootstrapServer;
     private final KafkaConnectPropertyFactory kafkaConnectPropertyFactory;
@@ -77,7 +78,7 @@ public class KafkaConnectRunner {
      *
      */
     private void init() {
-        log.info("Started worked initialization");
+        LOG.info("Started worked initialization");
 
         Time time = Time.SYSTEM;
 
@@ -109,7 +110,7 @@ public class KafkaConnectRunner {
          */
         herder = new StandaloneHerder(worker, kafkaClusterId);
         connect = new Connect(herder, rest);
-        log.info("Finished initializing the worker");
+        LOG.info("Finished initializing the worker");
     }
 
     /**
@@ -125,13 +126,12 @@ public class KafkaConnectRunner {
 
     private void callTestErrorHandler(Properties connectorProps, Throwable error) {
         if (error != null) {
-            log.error("Failed to create the connector");
+            LOG.error("Failed to create the connector");
             error.printStackTrace();
             TestCommon.failOnConnectorError(error, connectorProps,
                     (String) connectorProps.get(ConnectorConfig.NAME_CONFIG));
-        }
-        else {
-            log.debug("Created connector {}", connectorProps.get(ConnectorConfig.NAME_CONFIG));
+        } else {
+            LOG.debug("Created connector {}", connectorProps.get(ConnectorConfig.NAME_CONFIG));
         }
     }
 
@@ -150,11 +150,11 @@ public class KafkaConnectRunner {
     }
 
     private static void failOnKafkaConnectInitialization(Throwable error) {
-        log.error("Failed to initialize the embedded Kafka Connect Runtime: {}",
+        LOG.error("Failed to initialize the embedded Kafka Connect Runtime: {}",
                 error.getMessage(), error);
 
-        fail("Failed to initialize the embedded Kafka Connect Runtime: " +
-                error.getMessage());
+        fail("Failed to initialize the embedded Kafka Connect Runtime: "
+                + error.getMessage());
     }
 
     /**
@@ -164,14 +164,14 @@ public class KafkaConnectRunner {
     public boolean run() {
         init();
 
-        log.info("Starting the connect interface");
+        LOG.info("Starting the connect interface");
         connect.start();
-        log.info("Started the connect interface");
+        LOG.info("Started the connect interface");
 
         for (ConnectorPropertyFactory propertyProducer : connectorPropertyFactories) {
             try {
                 initializeConnector(propertyProducer);
-            } catch(InterruptedException | ExecutionException e){
+            } catch (InterruptedException | ExecutionException e) {
                 failOnKafkaConnectInitialization(e);
 
                 return false;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
@@ -6,33 +6,28 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package org.apache.camel.kafkaconnector;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
 import static junit.framework.TestCase.fail;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 /**
  * Common test constants and utilities
  */
 public final class TestCommon {
-    private static final Logger log = LoggerFactory.getLogger(TestCommon.class);
-
-    private TestCommon() {}
-
     /**
      * The default topic for usage during the tests
      */
@@ -48,9 +43,14 @@ public final class TestCommon {
      */
     public static final String DEFAULT_SQS_QUEUE = "ckc";
 
+    private static final Logger LOG = LoggerFactory.getLogger(TestCommon.class);
+
+    private TestCommon() {
+    }
+
 
     public static void failOnConnectorError(Throwable error, Properties connectorProps, String name) {
-        log.error("Failed to create job for {} with properties", name, connectorProps,
+        LOG.error("Failed to create job for {} with properties {}", name, connectorProps,
                 error);
         fail("Failed to create job for " + name);
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/ConsumerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/ConsumerPropertyFactory.java
@@ -6,14 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.clients.kafka;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/DefaultConsumerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/DefaultConsumerPropertyFactory.java
@@ -6,23 +6,21 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.clients.kafka;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.serialization.StringDeserializer;
-
 import java.util.Properties;
 import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 
 
 /**

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/DefaultProducerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/DefaultProducerPropertyFactory.java
@@ -6,23 +6,21 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.clients.kafka;
 
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringSerializer;
-
 import java.util.Properties;
 import java.util.UUID;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 
 public class DefaultProducerPropertyFactory implements ProducerPropertyFactory {
     private final String bootstrapServer;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/KafkaClient.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/KafkaClient.java
@@ -6,18 +6,23 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.clients.kafka;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Predicate;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -27,29 +32,22 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.function.Predicate;
-
 /**
  * A very simple test message consumer that can consume messages of different types
+ *
  * @param <K> Key type
  * @param <V> Value type
  */
-public class KafkaClient<K,V> {
-    private static final Logger log = LoggerFactory.getLogger(KafkaClient.class);
-
+public class KafkaClient<K, V> {
     private final ConsumerPropertyFactory propertyProducer;
     private final ProducerPropertyFactory producerPropertyFactory;
 
 
     /**
      * Constructs the properties using the given bootstrap server
+     *
      * @param bootstrapServer the address of the server in the format
-     *                       PLAINTEXT://${address}:${port}
+     *                        PLAINTEXT://${address}:${port}
      */
     public KafkaClient(String bootstrapServer) {
         this.propertyProducer = new DefaultConsumerPropertyFactory(bootstrapServer);
@@ -59,10 +57,11 @@ public class KafkaClient<K,V> {
 
     /**
      * Consumes message from the given topic until the predicate returns false
-     * @param topic the topic to consume the messages from
+     *
+     * @param topic     the topic to consume the messages from
      * @param predicate the predicate to test when the messages arrive
      */
-    public void consume(String topic, Predicate<ConsumerRecord<K,V>> predicate) {
+    public void consume(String topic, Predicate<ConsumerRecord<K, V>> predicate) {
         Properties props = propertyProducer.getProperties();
 
         KafkaConsumer<K, V> consumer = new KafkaConsumer<>(props);
@@ -82,7 +81,8 @@ public class KafkaClient<K,V> {
 
     /**
      * Sends data to a topic
-     * @param topic the topic to send data to
+     *
+     * @param topic   the topic to send data to
      * @param message the message to send
      * @throws ExecutionException
      * @throws InterruptedException

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/ProducerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/kafka/ProducerPropertyFactory.java
@@ -6,14 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.clients.kafka;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -6,23 +6,21 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.sink.aws.sqs;
 
+import java.util.Properties;
 import org.apache.camel.kafkaconnector.AWSConfigs;
 import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
-
-import java.util.Properties;
 
 
 /**
@@ -52,8 +50,8 @@ class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 
-        String queueUrl = "aws-sqs://" + queue + "?autoCreateQueue=false&accessKey=accesskey&protocol=http&amazonAWSHost=" +
-                amazonConfigs.getProperty(AWSConfigs.AMAZON_AWS_HOST, "localhost");
+        String queueUrl = "aws-sqs://" + queue + "?autoCreateQueue=false&accessKey=accesskey&protocol=http&amazonAWSHost="
+                + amazonConfigs.getProperty(AWSConfigs.AMAZON_AWS_HOST, "localhost");
         System.out.println("Queue URL => " + queueUrl);
         connectorProps.put("camel.sink.url", queueUrl);
         connectorProps.put("topics", topic);

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelSinkAWSSQSITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelSinkAWSSQSITCase.java
@@ -6,18 +6,25 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.sink.aws.sqs;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sqs.AmazonSQS;
@@ -34,7 +41,6 @@ import org.apache.camel.kafkaconnector.TestCommon;
 import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -42,19 +48,10 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.fail;
 
 public class CamelSinkAWSSQSITCase {
-    private static final Logger log = LoggerFactory.getLogger(CamelSinkAWSSQSITCase.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSinkAWSSQSITCase.class);
     private static final int SQS_PORT = 4576;
 
     @Rule
@@ -67,23 +64,23 @@ public class CamelSinkAWSSQSITCase {
     private KafkaConnectRunner kafkaConnectRunner;
     private AmazonSQS sqs;
 
-    private volatile int received = 0;
+    private volatile int received;
     private final int expect = 10;
 
     @Before
     public void setUp() {
         ContainerUtil.waitForInitialization(kafka);
-        log.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
+        LOG.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
 
-        log.info("Waiting for SQS initialization");
+        LOG.info("Waiting for SQS initialization");
         ContainerUtil.waitForHttpInitialization(localStackContainer, localStackContainer.getMappedPort(SQS_PORT));
-        log.info("SQS Initialized");
+        LOG.info("SQS Initialized");
 
         final String sqsInstance = localStackContainer
                 .getEndpointConfiguration(LocalStackContainer.Service.SQS)
                 .getServiceEndpoint();
 
-        log.info("SQS instance running at {}", sqsInstance);
+        LOG.info("SQS instance running at {}", sqsInstance);
 
         Properties properties = new Properties();
 
@@ -121,7 +118,7 @@ public class CamelSinkAWSSQSITCase {
             String queueUrl = sqs.createQueue(createFifoQueueRequest)
                     .getQueueUrl();
 
-            log.debug("Consuming messages from {}", queueUrl);
+            LOG.debug("Consuming messages from {}", queueUrl);
 
             ReceiveMessageRequest request = new ReceiveMessageRequest(queueUrl)
                     .withWaitTimeSeconds(10)
@@ -132,17 +129,15 @@ public class CamelSinkAWSSQSITCase {
 
                 List<Message> messages = result.getMessages();
                 for (Message message : messages) {
-                    log.info("Received: {}", message.getBody());
+                    LOG.info("Received: {}", message.getBody());
                     received++;
                 }
 
             }
-        }
-        catch (Throwable t) {
-            log.error("Failed to consume messages: {}", t.getMessage(), t);
+        } catch (Throwable t) {
+            LOG.error("Failed to consume messages: {}", t.getMessage(), t);
             fail(t.getMessage());
-        }
-        finally {
+        } finally {
             latch.countDown();
         }
     }
@@ -156,28 +151,27 @@ public class CamelSinkAWSSQSITCase {
             ExecutorService service = Executors.newFixedThreadPool(2);
             service.submit(() -> kafkaConnectRunner.run());
 
-            log.debug("Creating the consumer ...");
+            LOG.debug("Creating the consumer ...");
             service.submit(() -> consumeMessages(latch));
 
-            KafkaClient<String,String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+            KafkaClient<String, String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
 
             for (int i = 0; i < expect; i++) {
                 kafkaClient.produce(TestCommon.DEFAULT_TEST_TOPIC, "Sink test message " + i);
             }
 
-            log.debug("Created the consumer ... About to receive messages");
+            LOG.debug("Created the consumer ... About to receive messages");
 
             if (latch.await(120, TimeUnit.SECONDS)) {
                 Assert.assertTrue("Didn't process the expected amount of messages: " + received + " != " + expect,
                         received == expect);
-            }
-            else {
+            } else {
                 fail("Failed to receive the messages within the specified time");
             }
 
             kafkaConnectRunner.stop();
         } catch (Exception e) {
-            log.error("Amazon SQS test failed: {}", e.getMessage(), e);
+            LOG.error("Amazon SQS test failed: {}", e.getMessage(), e);
             fail(e.getMessage());
         }
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/jms/CamelJMSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/jms/CamelJMSPropertyFactory.java
@@ -6,22 +6,20 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.sink.jms;
 
+import java.util.Properties;
 import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
-
-import java.util.Properties;
 
 
 /**

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/jms/CamelJMSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/jms/CamelJMSPropertyFactory.java
@@ -6,22 +6,20 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.source.jms;
 
+import java.util.Properties;
 import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
-
-import java.util.Properties;
 
 
 /**

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/timer/CamelSourceTimerITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/timer/CamelSourceTimerITCase.java
@@ -6,18 +6,19 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.source.timer;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.camel.kafkaconnector.KafkaConnectRunner;
 import org.apache.camel.kafkaconnector.TestCommon;
 import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
@@ -26,10 +27,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
@@ -39,12 +36,12 @@ import org.testcontainers.containers.KafkaContainer;
  * messages
  */
 public class CamelSourceTimerITCase {
-    private static final Logger log = LoggerFactory.getLogger(CamelSourceTimerITCase.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSourceTimerITCase.class);
 
     @Rule
     public KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
 
-    private int received = 0;
+    private int received;
     private final int expect = 10;
     private KafkaConnectRunner kafkaConnectRunner;
 
@@ -59,7 +56,7 @@ public class CamelSourceTimerITCase {
 
         kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
 
-        log.info("Kafka bootstrap server running at address " + kafka.getBootstrapServers());
+        LOG.info("Kafka bootstrap server running at address " + kafka.getBootstrapServers());
 
 
     }
@@ -79,10 +76,10 @@ public class CamelSourceTimerITCase {
         ExecutorService service = Executors.newCachedThreadPool();
         service.submit(() -> kafkaConnectRunner.run());
 
-        log.debug("Creating the consumer ...");
-        KafkaClient<String,String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+        LOG.debug("Creating the consumer ...");
+        KafkaClient<String, String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
         kafkaClient.consume(TestCommon.DEFAULT_TEST_TOPIC, this::checkRecord);
-        log.debug("Created the consumer ...");
+        LOG.debug("Created the consumer ...");
 
         kafkaConnectRunner.stop();
         Assert.assertTrue(received == expect);

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/timer/CamelTimerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/timer/CamelTimerPropertyFactory.java
@@ -6,22 +6,20 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.camel.kafkaconnector.source.timer;
 
+import java.util.Properties;
 import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
-
-import java.util.Properties;
 
 class CamelTimerPropertyFactory implements ConnectorPropertyFactory {
     private final int tasksMax;


### PR DESCRIPTION
This is a follow up from #62. It fixes all the check style warnings/errors when running the build with -Psourcecheck.

I wanted to do this before continuing w/ the other integration tests, so it's easier to spot problems as new code is introduced.

The code changes should not introduce any logic change and are merely cosmetic. I validated the changes with the current set of unit/integration tests and it seems to be working fine.

