### PR TITLE
Adds support for loading and running custom classes during startup …

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkConnectorConfig.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkConnectorConfig.java
@@ -29,8 +29,12 @@ public class CamelSinkConnectorConfig extends AbstractConfig {
     public static final String CAMEL_SINK_MARSHAL_DEFAULT = null;
     public static final String CAMEL_SINK_MARSHAL_CONF = "camel.sink.marshal";
 
+    public static final String CAMEL_SINK_STARTUP_HELPER_DEFAULT = null;
+    public static final String CAMEL_SINK_STARTUP_HELPER_CONF = "camel.sink.startup.helper";
+
     private static final String CAMEL_SINK_URL_DOC = "The camel url to configure the destination";
     private static final String CAMEL_SINK_MARSHAL_DOC = "The camel dataformat name to use to marshal data to the destination";
+    private static final String CAMEL_SINK_STARTUP_HELPER_DOC = "A startup helper class that can be used to configure the camel sink main instance";
 
     public CamelSinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -43,6 +47,7 @@ public class CamelSinkConnectorConfig extends AbstractConfig {
     public static ConfigDef conf() {
         return new ConfigDef()
                 .define(CAMEL_SINK_URL_CONF, Type.STRING, CAMEL_SINK_URL_DEFAULT, Importance.HIGH, CAMEL_SINK_URL_DOC)
-                .define(CAMEL_SINK_MARSHAL_CONF, Type.STRING, CAMEL_SINK_MARSHAL_DEFAULT, Importance.HIGH, CAMEL_SINK_MARSHAL_DOC);
+                .define(CAMEL_SINK_MARSHAL_CONF, Type.STRING, CAMEL_SINK_MARSHAL_DEFAULT, Importance.HIGH, CAMEL_SINK_MARSHAL_DOC)
+                .define(CAMEL_SINK_STARTUP_HELPER_CONF, Type.STRING, CAMEL_SINK_STARTUP_HELPER_DEFAULT, Importance.LOW, CAMEL_SINK_STARTUP_HELPER_DOC);
     }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceConnectorConfig.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceConnectorConfig.java
@@ -47,6 +47,9 @@ public class CamelSourceConnectorConfig extends AbstractConfig {
     public static final Boolean CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT = true;
     public static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF = "camel.source.pollingConsumerBlockWhenFull";
 
+    public static final String CAMEL_SOURCE_STARTUP_HELPER_DEFAULT = null;
+    public static final String CAMEL_SOURCE_STARTUP_HELPER_CONF = "camel.source.startup.helper";
+
     private static final String CAMEL_SOURCE_URL_DOC = "The camel url to configure the source";
     private static final String CAMEL_SOURCE_UNMARSHAL_DOC = "The camel dataformat name to use to unmarshal data from the source";
     private static final String TOPIC_DOC = "The topic to publish data to";
@@ -55,6 +58,7 @@ public class CamelSourceConnectorConfig extends AbstractConfig {
     private static final String CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DOC = "The queue size for the internal hand-off queue between the polling consumer, and producers sending data into the queue.";
     private static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DOC = "To use a timeout (in milliseconds) when the producer is blocked if the internal queue is full. If the value is 0 or negative then no timeout is in use.";
     private static final String CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC = " Whether to block any producer if the internal queue is full.";
+    private static final String CAMEL_SOURCE_STARTUP_HELPER_DOC = "A startup helper class that can be used to configure the camel source main instance";
 
 
     public CamelSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
@@ -74,6 +78,7 @@ public class CamelSourceConnectorConfig extends AbstractConfig {
                 .define(CAMEL_SOURCE_MAX_POLL_DURATION_CONF, Type.LONG, CAMEL_SOURCE_MAX_POLL_DURATION_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_MAX_POLL_DURATION_DOC)
                 .define(CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_CONF, Type.LONG, CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_QUEUE_SIZE_DOC)
                 .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_CONF, Type.LONG, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_TIMEOUT_DOC)
-                .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF, Type.BOOLEAN, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC);
+                .define(CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_CONF, Type.BOOLEAN, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DEFAULT, Importance.MEDIUM, CAMEL_SOURCE_POLLING_CONSUMER_BLOCK_WHEN_FULL_DOC)
+                .define(CAMEL_SOURCE_STARTUP_HELPER_CONF, Type.STRING, CAMEL_SOURCE_STARTUP_HELPER_DEFAULT, Importance.LOW, CAMEL_SOURCE_STARTUP_HELPER_DOC);
     }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSourceTask.java
@@ -30,6 +30,8 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.PollingConsumer;
 import org.apache.camel.kafkaconnector.utils.CamelMainSupport;
+import org.apache.camel.kafkaconnector.utils.CamelStartupHelper;
+import org.apache.camel.kafkaconnector.utils.CamelStartupHelperUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -71,7 +73,10 @@ public class CamelSourceTask extends SourceTask {
 
             String localUrl = getLocalUrlWithPollingOptions(config);
 
-            cms = new CamelMainSupport(props, remoteUrl, localUrl, null, unmarshaller);
+            final String helperClass =  config.getString(CamelSourceConnectorConfig.CAMEL_SOURCE_STARTUP_HELPER_CONF);
+            final CamelStartupHelper startupHelper = CamelStartupHelperUtils.instantiateHelper(helperClass, props);
+
+            cms = new CamelMainSupport(props, remoteUrl, localUrl, null, unmarshaller, startupHelper);
 
             Endpoint endpoint = cms.getEndpoint(localUrl);
             consumer = endpoint.createPollingConsumer();

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelMainSupport.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelMainSupport.java
@@ -45,15 +45,16 @@ public class CamelMainSupport {
 
     private Main camelMain;
     private CamelContext camel;
+    private final CamelStartupHelper startupHelper;
 
     private final ExecutorService exService = Executors.newSingleThreadExecutor();
     private final CountDownLatch startFinishedSignal = new CountDownLatch(1);
 
-    public CamelMainSupport(Map<String, String> props, String fromUrl, String toUrl, String marshal, String unmarshal) throws Exception {
-        this(props, fromUrl, toUrl, marshal, unmarshal, new DefaultCamelContext());
+    public CamelMainSupport(Map<String, String> props, String fromUrl, String toUrl, String marshal, String unmarshal, CamelStartupHelper startupHelper) throws Exception {
+        this(props, fromUrl, toUrl, marshal, unmarshal, startupHelper, new DefaultCamelContext());
     }
 
-    public CamelMainSupport(Map<String, String> props, String fromUrl, String toUrl, String marshal, String unmarshal, CamelContext camelContext) throws Exception {
+    public CamelMainSupport(Map<String, String> props, String fromUrl, String toUrl, String marshal, String unmarshal, CamelStartupHelper startupHelper, CamelContext camelContext) throws Exception {
         this.camel = camelContext; //new DefaultCamelContext();
         camelMain = new Main() {
             @Override
@@ -104,10 +105,16 @@ public class CamelMainSupport {
                 rd.to(toUrl);
             }
         });
+
+        this.startupHelper = startupHelper;
     }
 
     public void start() throws Exception {
         log.info("Starting CamelContext");
+
+        if (startupHelper != null) {
+            startupHelper.onStart(camel);
+        }
 
         CamelContextStarter starter = new CamelContextStarter();
         exService.execute(starter);

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelStartupHelper.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelStartupHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.utils;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+
+public interface CamelStartupHelper {
+
+    void init(Map<String, String> props);
+    void onStart(CamelContext context);
+
+}

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelStartupHelperUtils.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelStartupHelperUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.utils;
+
+import java.util.Map;
+
+public final class CamelStartupHelperUtils {
+
+    private CamelStartupHelperUtils() {
+        
+    }
+
+    public static CamelStartupHelper instantiateHelper(String helperClass, Map<String, String> props) throws Exception {
+        if (helperClass == null) {
+            return null;
+        }
+
+        Class<?> clazz = Class.forName(helperClass);
+
+        Object object = clazz.newInstance();
+        if (object instanceof CamelStartupHelper) {
+
+
+            CamelStartupHelper helper = (CamelStartupHelper) object;
+
+            helper.init(props);
+
+            return helper;
+        }
+
+        throw new Exception(String.format("Invalid startup helper class: %s does not implement %s",
+                clazz.getName(), CamelStartupHelper.class.getName()));
+    }
+}

--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -66,7 +66,7 @@ public class DataFormatTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testBothDataFormatConfiguredError() throws Exception {
-        new CamelMainSupport(new HashMap<>(), "direct://start", "log://test", "syslog", "syslog");
+        new CamelMainSupport(new HashMap<>(), "direct://start", "log://test", "syslog", "syslog", null);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class DataFormatTest {
         props.put("camel.sink.marshal", "hl7");
 
         DefaultCamelContext dcc = new DefaultCamelContext();
-        CamelMainSupport cms = new CamelMainSupport(props, "direct://start", "log://test", null, "hl7", dcc);
+        CamelMainSupport cms = new CamelMainSupport(props, "direct://start", "log://test", null, "hl7", null, dcc);
 
 
         HL7DataFormat hl7df = new HL7DataFormat();
@@ -99,7 +99,7 @@ public class DataFormatTest {
         props.put("camel.dataformat.hl7.validate", "false");
 
         DefaultCamelContext dcc = new DefaultCamelContext();
-        CamelMainSupport cms = new CamelMainSupport(props, "direct://start", "log://test", null, "hl7", dcc);
+        CamelMainSupport cms = new CamelMainSupport(props, "direct://start", "log://test", null, "hl7", null, dcc);
 
         cms.start();
         HL7DataFormat hl7dfLoaded = dcc.getRegistry().lookupByNameAndType("hl7", HL7DataFormat.class);

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelAWSSQSCustomClientPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelAWSSQSCustomClientPropertyFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.source.aws.sqs;
+
+import java.util.Properties;
+
+import org.apache.camel.kafkaconnector.AWSConfigs;
+import org.apache.camel.kafkaconnector.CamelSinkConnectorConfig;
+import org.apache.camel.kafkaconnector.CamelSourceConnectorConfig;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+
+
+/**
+ * Creates the set of properties used by a Camel JMS Sink Connector
+ */
+class CamelAWSSQSCustomClientPropertyFactory implements ConnectorPropertyFactory {
+    private final int tasksMax;
+    private final String topic;
+    private final String queue;
+    private final Properties amazonConfigs;
+
+
+    CamelAWSSQSCustomClientPropertyFactory(int tasksMax, String topic, String queue, Properties amazonConfigs) {
+        this.tasksMax = tasksMax;
+        this.topic = topic;
+        this.queue = queue;
+        this.amazonConfigs = amazonConfigs;
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties connectorProps = new Properties();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSSQSSourceConnector");
+
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
+        connectorProps.put(CamelSourceConnectorConfig.CAMEL_SOURCE_STARTUP_HELPER_CONF,
+                SQSCustomClientConfiguration.class.getName());
+
+        connectorProps.put("camel.source.kafka.topic", topic);
+
+        String queueUrl = "aws-sqs://" + queue + "?autoCreateQueue=true";
+        connectorProps.put("camel.source.url", queueUrl);
+
+        connectorProps.put("camel.component.aws-sqs.configuration.access-key",
+                amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
+        connectorProps.put("camel.component.aws-sqs.configuration.secret-key",
+                amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
+        connectorProps.put("camel.component.aws-sqs.configuration.region",
+                amazonConfigs.getProperty(AWSConfigs.REGION, ""));
+
+        connectorProps.put(AWSConfigs.AMAZON_AWS_HOST,
+                amazonConfigs.getProperty(AWSConfigs.AMAZON_AWS_HOST, "localhost"));
+
+        return connectorProps;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelSourceAWSSQSCustomClientITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelSourceAWSSQSCustomClientITCase.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.source.aws.sqs;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.regions.Regions;
+import org.apache.camel.kafkaconnector.AWSConfigs;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kafkaconnector.ContainerUtil;
+import org.apache.camel.kafkaconnector.KafkaConnectRunner;
+import org.apache.camel.kafkaconnector.TestCommon;
+import org.apache.camel.kafkaconnector.clients.aws.sqs.AWSSQSClient;
+import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+public class CamelSourceAWSSQSCustomClientITCase {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSourceAWSSQSCustomClientITCase.class);
+    private static final int SQS_PORT = 4576;
+
+    @Rule
+    public KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+
+    @Rule
+    public LocalStackContainer localStackContainer = new LocalStackContainer()
+            .withServices(LocalStackContainer.Service.SQS);
+
+    private KafkaConnectRunner kafkaConnectRunner;
+    private AWSSQSClient awssqsClient;
+
+    private volatile int received;
+    private final int expect = 10;
+
+    @Before
+    public void setUp() {
+        ContainerUtil.waitForInitialization(kafka);
+        LOG.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
+
+        LOG.info("Waiting for SQS initialization");
+        ContainerUtil.waitForHttpInitialization(localStackContainer, localStackContainer.getMappedPort(SQS_PORT));
+        LOG.info("SQS Initialized");
+
+        final String sqsInstance = localStackContainer
+                .getEndpointConfiguration(LocalStackContainer.Service.SQS)
+                .getServiceEndpoint();
+
+        LOG.info("SQS instance running at {}", sqsInstance);
+
+        Properties properties = new Properties();
+
+        properties.put(AWSConfigs.AMAZON_AWS_HOST, "localhost:" + localStackContainer.getMappedPort(SQS_PORT));
+
+        AWSCredentials credentials = localStackContainer.getDefaultCredentialsProvider().getCredentials();
+
+        properties.put(AWSConfigs.ACCESS_KEY, credentials.getAWSAccessKeyId());
+        properties.put(AWSConfigs.SECRET_KEY, credentials.getAWSSecretKey());
+        properties.put(AWSConfigs.REGION, Regions.US_EAST_1.name());
+
+        ConnectorPropertyFactory testProperties = new CamelAWSSQSCustomClientPropertyFactory(1,
+                TestCommon.DEFAULT_TEST_TOPIC, TestCommon.DEFAULT_SQS_QUEUE, properties);
+
+        kafkaConnectRunner =  new KafkaConnectRunner(kafka.getBootstrapServers());
+        kafkaConnectRunner.getConnectorPropertyProducers().add(testProperties);
+
+        awssqsClient = new AWSSQSClient(localStackContainer);
+    }
+
+    private boolean checkRecord(ConsumerRecord<String, String> record) {
+        LOG.debug("Received: {}", record.value());
+        received++;
+
+        if (received == expect) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Test
+    public void testBasicSendReceive() {
+        ExecutorService service = Executors.newCachedThreadPool();
+        service.submit(() -> kafkaConnectRunner.run());
+
+        LOG.debug("Sending SQS messages");
+        for (int i = 0; i < expect; i++) {
+            awssqsClient.send(TestCommon.DEFAULT_SQS_QUEUE, "Test message " + i);
+        }
+        LOG.debug("Done sending SQS messages");
+
+        LOG.debug("Creating the consumer ...");
+        KafkaClient<String, String> kafkaClient = new KafkaClient<>(kafka.getBootstrapServers());
+        kafkaClient.consume(TestCommon.DEFAULT_TEST_TOPIC, this::checkRecord);
+        LOG.debug("Created the consumer ...");
+
+        kafkaConnectRunner.stop();
+        Assert.assertTrue("Didn't process the expected amount of messages", received == expect);
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/SQSCustomClientConfiguration.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/SQSCustomClientConfiguration.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.source.aws.sqs;
+
+import java.util.Map;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import org.apache.camel.CamelContext;
+import org.apache.camel.kafkaconnector.AWSConfigs;
+import org.apache.camel.kafkaconnector.utils.CamelStartupHelper;
+import org.apache.camel.spi.Registry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SQSCustomClientConfiguration implements CamelStartupHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(SQSCustomClientConfiguration.class);
+
+    private String amazonHost;
+    private String region;
+    private String accessKey;
+    private String secretKey;
+
+
+    private class TestAWSCredentialsProvider implements AWSCredentialsProvider {
+        @Override
+        public AWSCredentials getCredentials() {
+            return new AWSCredentials() {
+                @Override
+                public String getAWSAccessKeyId() {
+                    return accessKey;
+                }
+
+                @Override
+                public String getAWSSecretKey() {
+                    return secretKey;
+                }
+            };
+        }
+
+        @Override
+        public void refresh() {
+
+        }
+    }
+
+    @Override
+    public void init(Map<String, String> props) {
+        amazonHost = props.get(AWSConfigs.AMAZON_AWS_HOST);
+        region = Regions.valueOf(props.get("camel.component.aws-sqs.configuration.region")).getName();
+
+        accessKey = props.get("camel.component.aws-sqs.configuration.access-key");
+        secretKey = props.get("camel.component.aws-sqs.configuration.secret-key");
+
+        LOG.info("Loaded configuration for Test SQS client with amazon host set to {} and region set to {}",
+                amazonHost, region);
+    }
+
+    @Override
+    public void onStart(CamelContext context) {
+        LOG.debug("Running test client startup setup");
+        Registry registry = context.getRegistry();
+
+        AmazonSQS amazonSQSClient = getSQSClient();
+        registry.bind("amazonSQSClient", AmazonSQS.class, amazonSQSClient);
+    }
+
+    private AmazonSQS getSQSClient() {
+        AmazonSQSClientBuilder clientBuilder = AmazonSQSClientBuilder
+                .standard();
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        clientConfiguration.setProtocol(Protocol.HTTP);
+
+        clientBuilder
+                .withClientConfiguration(clientConfiguration)
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(amazonHost, region))
+                .withCredentials(new TestAWSCredentialsProvider());
+
+        return clientBuilder.build();
+    }
+}


### PR DESCRIPTION
This should allow, for example, configuring beans and increasing the client setup flexiblity for certain components (ie.: AWS SNS and SQS).

The reason I implemented this is because some clients like AWS gives you the flexibility to configure the underlying client according to your needs.

To do so, this PR adds support for 2 new configurations: 
* camel.sink.startup.helper
* camel.source.startup.helper

These are used to point to a class that implements CamelStartupHelper and receives both the map with all the properties setup for the sink/source (so that they can query it for other configurations) as well as the CamelContext which they can use to - for example - bind key/values on the Camel registry.

For the moment, the PR only has a test for this on top of the AWS SQS Source because I don't want to commit myself too much to this design without some feedback first. If this is good enough, then I'll send a separate PR with a test using this feature and the AWS SQS Sink.
