### PR TITLE
Remove parent from root pom.xml so we can do a mvn versions:set on this project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.kafkaconnector</groupId>
-        <artifactId>parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <relativePath>parent/pom.xml</relativePath>
-    </parent>
-
+    <groupId>org.apache.camel.kafkaconnector</groupId>
     <artifactId>camel-kafka-connector-aggregator</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Aggregator module for the Camel-Kafka-Connector project</name>


### PR DESCRIPTION
I'd like to remove the parent from the root pom.xml so that we can do a mvn versions:set at the root directory and so it builds okay within our pipeline.

I don't think there's any issue with doing that - the other modules (core/tests) both use parent as a parent.